### PR TITLE
Suppress stdout logging in dev

### DIFF
--- a/env/dev/resources/logback.xml
+++ b/env/dev/resources/logback.xml
@@ -33,7 +33,11 @@
         <AppenderRef ref="FILE"/>
     </logger>
     <root level="DEBUG">
-        <appender-ref ref="STDOUT"/>
+        <!-- <appender-ref ref="STDOUT"/> -->
+        <appender-ref ref="FILE"/>
+    </root>
+    <root level="INFO">
+        <!-- <appender-ref ref="STDOUT"/> -->
         <appender-ref ref="FILE"/>
     </root>
 </configuration>


### PR DESCRIPTION
Log to file only (info and debug levels). Allows working in REPL without getting log spam.