### PR TITLE
[FIX #206] Dynamically require commiteth.core in user namespace

### DIFF
--- a/env/dev/clj/user.clj
+++ b/env/dev/clj/user.clj
@@ -1,13 +1,14 @@
 (ns user
   (:require [mount.core :as mount]
-            [commiteth.figwheel :refer [start-fw stop-fw cljs]]
-            commiteth.core))
+            [commiteth.figwheel :refer [start-fw stop-fw cljs]]))
 
 (defn start []
-  (mount/start-without #'commiteth.core/repl-server))
+  (require 'commiteth.core)
+  (mount/start-without (ns-resolve 'commiteth.core 'repl-server)))
 
 (defn stop []
-  (mount/stop-except #'commiteth.core/repl-server))
+  (require 'commiteth.core)
+  (mount/stop-except (ns-resolve 'commiteth.core 'repl-server)))
 
 (defn restart []
   (stop)

--- a/project.clj
+++ b/project.clj
@@ -116,10 +116,6 @@
                    :uberjar-name   "commiteth.jar"
                    :source-paths   ["env/prod/clj"]
                    :resource-paths ["env/prod/resources"]}
-   ;; :precomp profile allows to compile classes from commiteth.eth.contracts
-   ;; namespace before compiling clojure code. Otherwise ClassNotFound exception
-   ;; will be thrown
-   :precomp {:target-path "target/base+system+user+dev/" }
    :dev   {:dependencies   [[prone "1.1.4"]
                             [ring/ring-mock "0.3.1"]
                             [ring/ring-devel "1.6.2"]
@@ -146,7 +142,7 @@
                :optimizations :none
                :pretty-print  true}}]}
 
-           :prep-tasks     ["build-contracts" ["with-profile" "precomp" "javac"]]
+           :prep-tasks     ["build-contracts" "javac"]
            :doo            {:build "test"}
            :source-paths   ["env/dev/clj" "test/clj"]
            :resource-paths ["env/dev/resources"]


### PR DESCRIPTION
Dynamic require of `commiteth.core` allows us to skip autoloading of Java classes during running of lein tasks using `:dev` profile, as described in associated [issue](https://github.com/status-im/open-bounty/issues/206).

Also it seems that `:precomp` profile is not necessary anymore, as its sole purpose seems to  run `build-contracts` without auto-invoking `user.clj` compilation (as its `:source-paths` do not include `env/dev/clj/user.clj`).