### PR TITLE
Dev fix: add cljs source paths to :dev profile and remove CIDER dep

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -69,7 +69,6 @@
             [lein-auto "0.1.2"]
             [lein-less "1.7.5"]
             [lein-shell "0.5.0"]
-            [cider/cider-nrepl "0.15.0-SNAPSHOT"]
             [lein-sha-version "0.1.1"]]
 
 
@@ -144,7 +143,7 @@
 
            :prep-tasks     ["build-contracts" "javac"]
            :doo            {:build "test"}
-           :source-paths   ["env/dev/clj" "test/clj"]
+           :source-paths   ["env/dev/clj" "test/clj" "src/cljs" "env/dev/cljs"]
            :resource-paths ["env/dev/resources"]
            :repl-options   {:init-ns user
                             :nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}


### PR DESCRIPTION
Additional source paths help to resolve the Piggieback REPL issue. I was
getting annoying "No such namespace" warnings for commiteth.* namespaces.

I am using vim-fireplace. Detailed flow to reproduce below:

1. Run `lein repl`.
2. In the repl, run `(use 'figwheel-sidecar.repl-api)`, `(start-figwheel!)`, `(start)`.
3. Inside Vim, run `:Piggieback (figwheel-sidecar.repl-api/repl-env)`

Now evaluate e.g. namespace declaration in `commiteth.common` namespace. Result:
```
clojure.lang.ExceptionInfo: No such namespace: commiteth.common, could not locate commiteth/common.cljs, commiteth/common.cljc, or JavaScript source providing "commiteth.common" in file <cljs repl> {:tag
:cljs/analysis-error}
        at clojure.core$ex_info.invokeStatic(core.clj:4617)
        at clojure.core$ex_info.invoke(core.clj:4617)
        at cljs.analyzer$error.invokeStatic(analyzer.cljc:697)
        at cljs.analyzer$error.invoke(analyzer.cljc:693)
        at cljs.analyzer$error.invokeStatic(analyzer.cljc:695)
        at cljs.analyzer$error.invoke(analyzer.cljc:693)
        at cljs.analyzer$analyze_deps.invokeStatic(analyzer.cljc:2128)
        at cljs.analyzer$analyze_deps.invoke(analyzer.cljc:2102)
        at cljs.analyzer$ns_side_effects.invokeStatic(analyzer.cljc:3467)
        at cljs.analyzer$ns_side_effects.invoke(analyzer.cljc:3462)
        at cljs.analyzer$analyze_STAR_$fn__3361.invoke(analyzer.cljc:3586)
        at clojure.lang.PersistentVector.reduce(PersistentVector.java:341)
        at clojure.core$reduce.invokeStatic(core.clj:6544)
        at clojure.core$reduce.invoke(core.clj:6527)
        at cljs.analyzer$analyze_STAR_.invokeStatic(analyzer.cljc:3586)
        at cljs.analyzer$analyze_STAR_.invoke(analyzer.cljc:3576)
        at cljs.analyzer$analyze.invokeStatic(analyzer.cljc:3610)
        at cljs.analyzer$analyze.invoke(analyzer.cljc:3593)
        at cljs.repl$evaluate_form$fn__16437.invoke(repl.cljc:508)
        at cljs.repl$evaluate_form.invokeStatic(repl.cljc:507)
        at cljs.repl$evaluate_form.invoke(repl.cljc:452)
        at cljs.repl$eval_cljs.invokeStatic(repl.cljc:625)
        at cljs.repl$eval_cljs.invoke(repl.cljc:618)
        at cljs.repl$repl_STAR_$read_eval_print__16558.invoke(repl.cljc:880)
        at cljs.repl$repl_STAR_$fn__16566$fn__16575.invoke(repl.cljc:925)
        at cljs.repl$repl_STAR_$fn__16566.invoke(repl.cljc:924)
        at cljs.compiler$with_core_cljs.invokeStatic(compiler.cljc:1271)
        at cljs.compiler$with_core_cljs.invoke(compiler.cljc:1260)
        at cljs.repl$repl_STAR_.invokeStatic(repl.cljc:888)
        at cljs.repl$repl_STAR_.invoke(repl.cljc:760)
        at cemerick.piggieback$run_cljs_repl.invokeStatic(piggieback.clj:169)
        at cemerick.piggieback$run_cljs_repl.invoke(piggieback.clj:155)
        at clojure.lang.AFn.applyToHelper(AFn.java:171)
        at clojure.lang.AFn.applyTo(AFn.java:144)
        at clojure.core$apply.invokeStatic(core.clj:650)
        at clojure.core$apply.invoke(core.clj:641)
        at cemerick.piggieback$evaluate.invokeStatic(piggieback.clj:259)
        at cemerick.piggieback$evaluate.invoke(piggieback.clj:255)
        at clojure.lang.Var.invoke(Var.java:379)
        at cemerick.piggieback$wrap_cljs_repl$fn__29047$fn__29049$fn__29050.invoke(piggieback.clj:291)
        at cemerick.piggieback$enqueue$fn__29033.invoke(piggieback.clj:247)
        at clojure.tools.nrepl.middleware.interruptible_eval$run_next$fn__25452.invoke(interruptible_eval.clj:190)
        at clojure.lang.AFn.run(AFn.java:22)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```