### PR TITLE
[FIX #185] Readd bounty label

### DIFF
--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -125,6 +125,15 @@ INSERT INTO issues (repo_id, issue_id, issue_number, title)
                    FROM issues
                    WHERE repo_id = :repo_id AND issue_id = :issue_id);
 
+-- :name remove-issue! :<! :1
+-- :doc removes issue
+DELETE FROM issues
+  WHERE repo_id = :repo_id 
+  AND issue_id = :issue_id
+  AND value_usd = 0.0
+  RETURNING comment_id;
+
+
 -- :name update-commit-sha :<! :1
 -- :doc updates issue with commit_sha
 UPDATE issues

--- a/src/clj/commiteth/bounties.clj
+++ b/src/clj/commiteth/bounties.clj
@@ -58,6 +58,16 @@
       (log/debug "Total issues for repo limit reached " repo " " count)
       (add-bounty-for-issue repo repo-id issue))))
 
+(defn remove-bounty-for-issue [repo repo-id issue]
+  (let [{issue-id     :id
+         issue-number :number} issue
+        removed-issue (issues/remove repo-id issue-id)
+        {owner-address :address
+         owner :owner} (users/get-repo-owner repo-id) ]
+    (log/debug "Removing bounty for issue " repo issue-number "owner address: " owner-address)
+    (if-let [comment-id (:comment_id removed-issue)]
+      (github/remove-deploying-comment owner repo comment-id)
+      (log/debug "Cannot remove Github bounty comment as it has non-zero value"))))
 
 ;; We have a max-limit to ensure people can't add more issues and
 ;; drain bot account until we have economic design in place

--- a/src/clj/commiteth/db/issues.clj
+++ b/src/clj/commiteth/db/issues.clj
@@ -12,6 +12,14 @@
                               :issue_number issue-number
                               :title        issue-title})))
 
+(defn remove
+  "Removes issue"
+  [repo-id issue-id]
+  (jdbc/with-db-connection [con-db *db*]
+    (db/remove-issue! con-db {:repo_id      repo-id
+                              :issue_id     issue-id})))
+
+
 (defn update-commit-sha
   "Updates issue with commit-sha"
   [issue-id commit-sha]

--- a/src/clj/commiteth/github/core.clj
+++ b/src/clj/commiteth/github/core.clj
@@ -275,6 +275,10 @@
     (log/debug "Posting comment to" (str owner "/" repo "/" issue-number) ":" comment)
     (issues/create-comment owner repo issue-number comment (self-auth-params))))
 
+(defn remove-deploying-comment
+  [owner repo comment-id]
+  (issues/delete-comment owner repo comment-id (self-auth-params)))
+
 (defn make-patch-request [end-point positional query]
   (let [{:keys [auth oauth-token]
          :as   query} query

--- a/src/cljs/commiteth/activity.cljs
+++ b/src/cljs/commiteth/activity.cljs
@@ -58,19 +58,25 @@
 
 
 (defn activity-list [activity-page-data]
-  [:div.ui.container.activity-container
-   {:id "activity-container"}
-   (if (empty? (:items activity-page-data))
-     [:div.view-no-data-container
-      [:p "No recent activity yet"]]
-     (display-data-page activity-page-data activity-item :set-activity-page-number))])
+  (if (empty? (:items activity-page-data))
+    [:div.view-no-data-container
+     [:p "No recent activity yet"]]
+    (display-data-page activity-page-data activity-item :set-activity-page-number)))
 
 (defn activity-page []
   (let [activity-page-data (rf/subscribe [:activities-page])
-        activity-feed-loading? (rf/subscribe [:get-in [:activity-feed-loading?]])]
-    (fn []
-      (if @activity-feed-loading?
-        [:div.view-loading-container
-         [:div.ui.active.inverted.dimmer
-          [:div.ui.text.loader.view-loading-label "Loading"]]]
-        [activity-list @activity-page-data]))))
+        activity-feed-loading? (rf/subscribe [:get-in [:activity-feed-loading?]])
+        container-element (atom nil) 
+        render-fn (fn []
+                    (if @activity-feed-loading?
+                      [:div.view-loading-container
+                       [:div.ui.active.inverted.dimmer
+                        [:div.ui.text.loader.view-loading-label "Loading"]]]
+                      [:div.ui.container.activity-container
+                       {:ref #(reset! container-element %1)} 
+                       [activity-list @activity-page-data]]))]
+    (r/create-class
+      {:component-did-update (fn [] 
+                               (when @container-element
+                                 (.scrollIntoView @container-element)))
+       :reagent-render render-fn})))

--- a/src/cljs/commiteth/activity.cljs
+++ b/src/cljs/commiteth/activity.cljs
@@ -59,6 +59,7 @@
 
 (defn activity-list [activity-page-data]
   [:div.ui.container.activity-container
+   {:id "activity-container"}
    (if (empty? (:items activity-page-data))
      [:div.view-no-data-container
       [:p "No recent activity yet"]]

--- a/src/cljs/commiteth/bounties.cljs
+++ b/src/cljs/commiteth/bounties.cljs
@@ -3,6 +3,7 @@
             [reagent.core :as r]
             [commiteth.common :refer [moment-timestamp
                                       display-data-page
+                                      scroll-div
                                       items-per-page
                                       issue-url]]))
 
@@ -55,23 +56,20 @@
            right (dec (+ left item-count))]
        [:div.item-counts-label
         [:span (str "Showing " left "-" right " of " total-count)]])
-     (display-data-page bounty-page-data bounty-item :set-bounty-page-number)]))
+     (display-data-page bounty-page-data bounty-item)]))
 
 (defn bounties-page []
   (let [bounty-page-data (rf/subscribe [:open-bounties-page])
         open-bounties-loading? (rf/subscribe [:get-in [:open-bounties-loading?]])
-        container-element (atom nil) 
-        render-fn (fn []
-                    (if @open-bounties-loading?
-                      [:div.view-loading-container
-                       [:div.ui.active.inverted.dimmer
-                        [:div.ui.text.loader.view-loading-label "Loading"]]]
-                      [:div.ui.container.open-bounties-container
-                       {:ref #(reset! container-element %1)} 
-                       [:div.open-bounties-header "Bounties"]
-                       [bounties-list @bounty-page-data]]))]
-    (r/create-class
-      {:component-did-update (fn [] 
-                               (when @container-element
-                                 (.scrollIntoView @container-element)))
-       :reagent-render render-fn})))
+        container-element (atom nil)] 
+    (fn []
+      (if @open-bounties-loading?
+        [:div.view-loading-container
+         [:div.ui.active.inverted.dimmer
+          [:div.ui.text.loader.view-loading-label "Loading"]]]
+        [:div.ui.container.open-bounties-container
+         {:ref #(reset! container-element %1)} 
+         [scroll-div container-element]
+         [:div.open-bounties-header "Bounties"]
+         [bounties-list @bounty-page-data]]))
+    ))

--- a/src/cljs/commiteth/bounties.cljs
+++ b/src/cljs/commiteth/bounties.cljs
@@ -1,5 +1,6 @@
 (ns commiteth.bounties
   (:require [re-frame.core :as rf]
+            [reagent.core :as r]
             [commiteth.common :refer [moment-timestamp
                                       display-data-page
                                       items-per-page
@@ -46,25 +47,31 @@
 
 (defn bounties-list [{:keys [items item-count page-number total-count] 
                       :as bounty-page-data}]
-  [:div.ui.container.open-bounties-container
-   {:id "open-bounties-container"}
-   [:div.open-bounties-header "Bounties"]
-   (if (empty? items)
-     [:div.view-no-data-container
-      [:p "No recent activity yet"]]
-     [:div
-      (let [left (inc (* (dec page-number) items-per-page))
-            right (dec (+ left item-count))]
-        [:div.item-counts-label
-         [:span (str "Showing " left "-" right " of " total-count)]])
-      (display-data-page bounty-page-data bounty-item :set-bounty-page-number)])])
+  (if (empty? items)
+    [:div.view-no-data-container
+     [:p "No recent activity yet"]]
+    [:div
+     (let [left (inc (* (dec page-number) items-per-page))
+           right (dec (+ left item-count))]
+       [:div.item-counts-label
+        [:span (str "Showing " left "-" right " of " total-count)]])
+     (display-data-page bounty-page-data bounty-item :set-bounty-page-number)]))
 
 (defn bounties-page []
   (let [bounty-page-data (rf/subscribe [:open-bounties-page])
-        open-bounties-loading? (rf/subscribe [:get-in [:open-bounties-loading?]])]
-    (fn []
-      (if @open-bounties-loading?
-        [:div.view-loading-container
-         [:div.ui.active.inverted.dimmer
-          [:div.ui.text.loader.view-loading-label "Loading"]]]
-        [bounties-list @bounty-page-data]))))
+        open-bounties-loading? (rf/subscribe [:get-in [:open-bounties-loading?]])
+        container-element (atom nil) 
+        render-fn (fn []
+                    (if @open-bounties-loading?
+                      [:div.view-loading-container
+                       [:div.ui.active.inverted.dimmer
+                        [:div.ui.text.loader.view-loading-label "Loading"]]]
+                      [:div.ui.container.open-bounties-container
+                       {:ref #(reset! container-element %1)} 
+                       [:div.open-bounties-header "Bounties"]
+                       [bounties-list @bounty-page-data]]))]
+    (r/create-class
+      {:component-did-update (fn [] 
+                               (when @container-element
+                                 (.scrollIntoView @container-element)))
+       :reagent-render render-fn})))

--- a/src/cljs/commiteth/bounties.cljs
+++ b/src/cljs/commiteth/bounties.cljs
@@ -47,15 +47,16 @@
 (defn bounties-list [{:keys [items item-count page-number total-count] 
                       :as bounty-page-data}]
   [:div.ui.container.open-bounties-container
+   {:id "open-bounties-container"}
    [:div.open-bounties-header "Bounties"]
    (if (empty? items)
      [:div.view-no-data-container
       [:p "No recent activity yet"]]
-     [:div 
+     [:div
       (let [left (inc (* (dec page-number) items-per-page))
             right (dec (+ left item-count))]
         [:div.item-counts-label
-            [:span (str "Showing " left "-" right " of " total-count)]])
+         [:span (str "Showing " left "-" right " of " total-count)]])
       (display-data-page bounty-page-data bounty-item :set-bounty-page-number)])])
 
 (defn bounties-page []

--- a/src/cljs/commiteth/common.cljs
+++ b/src/cljs/commiteth/common.cljs
@@ -123,8 +123,9 @@
           [:div
            [draw-items] 
            [:div.page-nav-container
-            [draw-rect :backward]
-            [draw-rect :forward]
+            [:div.page-direction-container
+             [draw-rect :backward]
+             [draw-rect :forward]]
             [:div.page-nav-text [:span (str "Page " page-number " of " page-count)]]
             [draw-page-numbers page-number page-count]]])))
 

--- a/src/cljs/commiteth/db.cljs
+++ b/src/cljs/commiteth/db.cljs
@@ -8,8 +8,7 @@
    :activity-feed-loading? false
    :open-bounties-loading? false
    :open-bounties []
-   :bounty-page-number 1
-   :activity-page-number 1
+   :page-number 1
    :owner-bounties   {}
    :top-hunters []
    :activity-feed []})

--- a/src/cljs/commiteth/handlers.cljs
+++ b/src/cljs/commiteth/handlers.cljs
@@ -6,7 +6,6 @@
                                    reg-fx
                                    inject-cofx]]
             [ajax.core :refer [GET POST]]
-            [clojure.browser.dom :as dom :refer [get-element]]
             [cuerdas.core :as str]
             [cljs-web3.core :as web3]
             [cljs-web3.eth :as web3-eth]

--- a/src/cljs/commiteth/handlers.cljs
+++ b/src/cljs/commiteth/handlers.cljs
@@ -6,6 +6,7 @@
                                    reg-fx
                                    inject-cofx]]
             [ajax.core :refer [GET POST]]
+            [clojure.browser.dom :as dom :refer [get-element]]
             [cuerdas.core :as str]
             [cljs-web3.core :as web3]
             [cljs-web3.eth :as web3-eth]
@@ -38,6 +39,15 @@
    (println "redirecting to" path)
    (set! (.-pathname js/location) path)))
 
+(reg-fx
+  :bounty-scroll-pos
+  (fn [scroll-pos]
+    (.scrollIntoView (get-element "open-bounties-container")) ))
+
+(reg-fx
+  :activity-scroll-pos
+  (fn [scroll-pos]
+    (.scrollIntoView (get-element "activity-container"))))
 
 (reg-event-fx
  :initialize-db
@@ -68,15 +78,17 @@
  (fn [db [_ page]]
    (assoc db :page page)))
 
-(reg-event-db
+(reg-event-fx
   :set-bounty-page-number
-  (fn [db [_ page]]
-    (assoc db :bounty-page-number page)))
+  (fn [{:keys [db]} [_ page]]
+    {:db (assoc db :bounty-page-number page)
+     :bounty-scroll-pos 0}))
 
-(reg-event-db
+(reg-event-fx
   :set-activity-page-number
-  (fn [db [_ page]]
-    (assoc db :activity-page-number page)))
+  (fn [{:keys [db]} [_ page]]
+    {:db (assoc db :activity-page-number page)
+     :activity-scroll-pos 0}))
 
 (reg-event-fx
  :set-flash-message

--- a/src/cljs/commiteth/handlers.cljs
+++ b/src/cljs/commiteth/handlers.cljs
@@ -39,16 +39,6 @@
    (println "redirecting to" path)
    (set! (.-pathname js/location) path)))
 
-(reg-fx
-  :bounty-scroll-pos
-  (fn [scroll-pos]
-    (.scrollIntoView (get-element "open-bounties-container")) ))
-
-(reg-fx
-  :activity-scroll-pos
-  (fn [scroll-pos]
-    (.scrollIntoView (get-element "activity-container"))))
-
 (reg-event-fx
  :initialize-db
  [(inject-cofx :store)]
@@ -78,17 +68,15 @@
  (fn [db [_ page]]
    (assoc db :page page)))
 
-(reg-event-fx
+(reg-event-db
   :set-bounty-page-number
-  (fn [{:keys [db]} [_ page]]
-    {:db (assoc db :bounty-page-number page)
-     :bounty-scroll-pos 0}))
+  (fn [db [_ page]]
+    (assoc db :bounty-page-number page)))
 
-(reg-event-fx
+(reg-event-db
   :set-activity-page-number
-  (fn [{:keys [db]} [_ page]]
-    {:db (assoc db :activity-page-number page)
-     :activity-scroll-pos 0}))
+  (fn [db [_ page]]
+    (assoc db :activity-page-number page)))
 
 (reg-event-fx
  :set-flash-message

--- a/src/cljs/commiteth/handlers.cljs
+++ b/src/cljs/commiteth/handlers.cljs
@@ -63,19 +63,15 @@
 
 
 (reg-event-db
- :set-active-page
- (fn [db [_ page]]
-   (assoc db :page page)))
+  :set-active-page
+  (fn [db [_ page]]
+    (assoc db :page page
+           :page-number 1)))
 
 (reg-event-db
-  :set-bounty-page-number
+  :set-page-number
   (fn [db [_ page]]
-    (assoc db :bounty-page-number page)))
-
-(reg-event-db
-  :set-activity-page-number
-  (fn [db [_ page]]
-    (assoc db :activity-page-number page)))
+    (assoc db :page-number page)))
 
 (reg-event-fx
  :set-flash-message
@@ -89,7 +85,6 @@
  :clear-flash-message
  (fn [db _]
    (dissoc db :flash-message)))
-
 
 (defn assoc-in-if-not-empty [m path val]
   (if (seq val)

--- a/src/cljs/commiteth/subscriptions.cljs
+++ b/src/cljs/commiteth/subscriptions.cljs
@@ -37,14 +37,14 @@
     (vec (:open-bounties db))))
 
 (reg-sub
-  :bounty-page-number
+  :page-number
   (fn [db _]
-    (:bounty-page-number db)))
+    (:page-number db)))
 
 (reg-sub
   :open-bounties-page
   :<- [:open-bounties]
-  :<- [:bounty-page-number]
+  :<- [:page-number]
   (fn [[open-bounties page-number] _]
     (let [total-count (count open-bounties)
           start (* (dec page-number) items-per-page)
@@ -78,14 +78,9 @@
     (vec (:activity-feed db))))
 
 (reg-sub
-  :activity-page-number
-  (fn [db _]
-    (:activity-page-number db)))
-
-(reg-sub
   :activities-page
   :<- [:activity-feed]
-  :<- [:activity-page-number]
+  :<- [:page-number]
   (fn [[activities page-number] _]
     (let [total-count (count activities)
           start (* (dec page-number) items-per-page)

--- a/src/less/style.less
+++ b/src/less/style.less
@@ -887,6 +887,7 @@ body {
   flex: none;
   align-items: center;
   justify-content: center;
+  cursor: pointer;
 }
 
 .grayed-out {

--- a/src/less/style.less
+++ b/src/less/style.less
@@ -919,15 +919,6 @@ body {
     filter: fliph;
 }
 
-.pagination-text {
-	width: 83px;
-	height: 15px;
-	font-family: PostGrotesk;
-	font-size: 15px;
-	text-align: center;
-	color: #8d99a4;
-}
-
 .icon-forward-gray {
 	width: 24px;
 	height: 24px;
@@ -937,10 +928,24 @@ body {
 .page-nav-container {
   display: flex;
   margin: 0 -6px;
+  @media (max-width: 767px) {
+    align-items: center;
+    flex-direction: column;
+  }
+}
+
+.page-direction-container {
+  display: flex;
+  @media (max-width: 767px) {
+    flex-direction: row;
+  }
 }
 
 .page-nums-container {
   display: flex;
+  @media (max-width: 767px) {
+    display: none;
+  }
   margin-left: auto;
   justify-content: space-between;
 }
@@ -955,6 +960,10 @@ body {
   flex: none;
   align-items: center;
   justify-content: center;
+
+  @media (max-width: 767px) {
+    margin-top: 12px;
+  }
 }
 
 .item-counts-label {

--- a/src/less/style.less
+++ b/src/less/style.less
@@ -523,7 +523,7 @@
         }
     }
 
-    border: #e7e7e7 solid 0.1em!important;
+    border-bottom: #eaecee 1px solid !important;
     box-shadow: none!important;
     border-radius: 0.3em!important;
     padding: 0.8em 1em 1.1em!important;
@@ -588,9 +588,16 @@
 }
 
 .activity-container {
+    background-color: #fff;
     transform: translate(0, -45px);
     border-radius: 10px;
-
+    padding: 24px;
+    .activity-header {
+        font-family: "PostGrotesk-Medium";
+        font-size: 21px;
+        font-weight: 500;
+        color: #42505c;
+    }
 }
 
 .footer-row {
@@ -890,10 +897,17 @@ body {
   cursor: pointer;
 }
 
-.grayed-out {
+.grayed-out-page-num {
   color: #8d99a4;
   background-color: #f2f5f8;
   opacity: 1.0;
+}
+
+.grayed-out-direction {
+  color: #8d99a4;
+  background-color: #f2f5f8;
+  opacity: 0.4;
+  cursor: auto
 }
 
 .flip-horizontal {


### PR DESCRIPTION
# Description
This fix does the following:

1. Listen to `unlabeled` events from GitHub API.
2. If such event is received, find the associated issue in the DB and remove it only if funds are zero (currently it checks the field `value_usd` field). This removes the bounty from SOB.
3. If it is successfully deleted from the DB, post to GitHub API  a request to delete a comment. This will remove a bounty comment on GitHub.
4. No actions on part of the contract itself are done.

# Questions
1. Is `value_usd` the correct field to check against when removing a bounty?
2. Should anything be done with regards to the bounty contract when the parent comment is deleted? If so, what messages should be sent?

**Status**: WIP