### PR TITLE
[FIX #187] Fix address dropdown in My Payment Details

### DIFF
--- a/src/cljs/commiteth/common.cljs
+++ b/src/cljs/commiteth/common.cljs
@@ -10,18 +10,19 @@
      (merge props {:type      "text"
                    :value     @val-ratom
                    :on-change #(reset! val-ratom (-> % .-target .-value))})]))
-
 (defn dropdown [props title val-ratom items]
   (fn []
-    (if (= 1 (count items))
-      (reset! val-ratom (first items)))
     [:select.ui.basic.selection.dropdown
      (merge props {:on-change
-                   #(reset! val-ratom (-> % .-target .-value))})
-     (doall (for [item items]
-              ^{:key item} [:option
-                            {:value item}
-                            item]))]))
+                   #(let [selected-value (-> % .-target .-value)]
+                      (when (not= selected-value title)
+                        (reset! val-ratom selected-value)))
+                   :default-value (if (contains? (set items) @val-ratom) 
+                                    @val-ratom
+                                    title)})
+     (conj (doall (for [item items]
+                    ^{:key item} [:option {:value item} item]))
+           ^{:key title} [:option {:value title :disabled true} title])]))
 
 (defn moment-timestamp [time]
   (let [now (.now js/Date.)

--- a/src/cljs/commiteth/common.cljs
+++ b/src/cljs/commiteth/common.cljs
@@ -13,23 +13,16 @@
 
 (defn dropdown [props title val-ratom items]
   "If val-ratom is set, preselect it in the dropdown.
-   Add value of val-ratom if it's missing from items list.
-   Otherwise, prepend title as a disabled option"
-  (let [items (cond->> items
-                  (and @val-ratom
-                       (not (contains? (set items) @val-ratom)))
-                  (into [@val-ratom])
-                  (not @val-ratom)
-                  (into [title]))]
-    (fn []
-      [:select.ui.basic.selection.dropdown
-       (merge props {:on-change
-                     #(reset! val-ratom (-> % .-target .-value))
-                     :default-value (or @val-ratom title)})
-       (for [item items]
-                ^{:key item} [:option {:value item
-                                       :disabled (= item title)} 
-                              item])])))
+   Otherwise, prepend title as a disabled option."
+  (fn []
+    [:select.ui.basic.selection.dropdown
+     (merge props {:on-change
+                   #(reset! val-ratom (-> % .-target .-value))
+                   :default-value (or @val-ratom title)})
+     (for [item items]
+       ^{:key item} [:option {:value item
+                              :disabled (= item title)} 
+                     item])]))
 
 (defn moment-timestamp [time]
   (let [now (.now js/Date.)

--- a/src/cljs/commiteth/common.cljs
+++ b/src/cljs/commiteth/common.cljs
@@ -10,19 +10,26 @@
      (merge props {:type      "text"
                    :value     @val-ratom
                    :on-change #(reset! val-ratom (-> % .-target .-value))})]))
+
 (defn dropdown [props title val-ratom items]
-  (fn []
-    [:select.ui.basic.selection.dropdown
-     (merge props {:on-change
-                   #(let [selected-value (-> % .-target .-value)]
-                      (when (not= selected-value title)
-                        (reset! val-ratom selected-value)))
-                   :default-value (if (contains? (set items) @val-ratom) 
-                                    @val-ratom
-                                    title)})
-     (conj (doall (for [item items]
-                    ^{:key item} [:option {:value item} item]))
-           ^{:key title} [:option {:value title :disabled true} title])]))
+  "If val-ratom is set, preselect it in the dropdown.
+   Add value of val-ratom if it's missing from items list.
+   Otherwise, prepend title as a disabled option"
+  (let [items (cond-> items
+                  (and @val-ratom
+                       (not (contains? (set items) @val-ratom)))
+                  (conj @val-ratom)
+                  (not @val-ratom)
+                  (conj title))]
+    (fn []
+      [:select.ui.basic.selection.dropdown
+       (merge props {:on-change
+                     #(reset! val-ratom (-> % .-target .-value))
+                     :default-value (or @val-ratom title)})
+       (doall (for [item items]
+                ^{:key item} [:option {:value item
+                                       :disabled (= item title)} 
+                              item]))])))
 
 (defn moment-timestamp [time]
   (let [now (.now js/Date.)

--- a/src/cljs/commiteth/common.cljs
+++ b/src/cljs/commiteth/common.cljs
@@ -15,21 +15,21 @@
   "If val-ratom is set, preselect it in the dropdown.
    Add value of val-ratom if it's missing from items list.
    Otherwise, prepend title as a disabled option"
-  (let [items (cond-> items
+  (let [items (cond->> items
                   (and @val-ratom
                        (not (contains? (set items) @val-ratom)))
-                  (conj @val-ratom)
+                  (into [@val-ratom])
                   (not @val-ratom)
-                  (conj title))]
+                  (into [title]))]
     (fn []
       [:select.ui.basic.selection.dropdown
        (merge props {:on-change
                      #(reset! val-ratom (-> % .-target .-value))
                      :default-value (or @val-ratom title)})
-       (doall (for [item items]
+       (for [item items]
                 ^{:key item} [:option {:value item
                                        :disabled (= item title)} 
-                              item]))])))
+                              item])])))
 
 (defn moment-timestamp [time]
   (let [now (.now js/Date.)

--- a/src/cljs/commiteth/handlers.cljs
+++ b/src/cljs/commiteth/handlers.cljs
@@ -324,7 +324,7 @@
     :http {:method     POST
            :url        "/api/user/address"
            :on-success #(do
-                          (dispatch [:assoc-in [:user [:address] address]])
+                          (dispatch [:assoc-in [:user :address] address])
                           (dispatch [:set-flash-message
                                      :success
                                      "Address saved"]))

--- a/src/cljs/commiteth/update_address.cljs
+++ b/src/cljs/commiteth/update_address.cljs
@@ -11,9 +11,8 @@
   (let [db (rf/subscribe [:db])
         user (rf/subscribe [:user])
         updating-address (rf/subscribe [:get-in [:updating-address]])
-        address (-> @(rf/subscribe [:get-in [:user :address]]) 
-                    str/lower-case 
-                    r/atom)]
+        address (r/atom (some-> @(rf/subscribe [:get-in [:user :address]]) 
+                                str/lower-case))]
     (fn []
       (let [web3 (:web3 @db)
             web3-accounts (when web3

--- a/src/cljs/commiteth/update_address.cljs
+++ b/src/cljs/commiteth/update_address.cljs
@@ -24,10 +24,21 @@
           [:p "Insert your Ethereum address in hex format."]
           [:div.field
            (if-not (empty? web3-accounts)
-             [dropdown {:class "address-input"} 
-              "Select address"
-              address
-              (map str/lower-case web3-accounts)]
+             ; Add value of address if it's missing from items list.
+             ; If address is empty, add title 
+             (let [accounts (map str/lower-case web3-accounts)
+                   addr @address
+                   title "Select address"
+                   items (cond->> accounts
+                           (and addr
+                                (not (contains? (set accounts) addr)))
+                           (into [addr])
+                           (not addr)
+                           (into [title]))]
+               [dropdown {:class "address-input"} 
+                title
+                address
+                items])
              [:div.ui.input.address-input
               [input address {:placeholder "0x0000000000000000000000000000000000000000"
                               :auto-complete "off"

--- a/src/cljs/commiteth/update_address.cljs
+++ b/src/cljs/commiteth/update_address.cljs
@@ -11,8 +11,7 @@
   (let [db (rf/subscribe [:db])
         user (rf/subscribe [:user])
         updating-address (rf/subscribe [:get-in [:updating-address]])
-        address (r/atom (some-> @(rf/subscribe [:get-in [:user :address]]) 
-                                str/lower-case))]
+        address (r/atom @(rf/subscribe [:get-in [:user :address]]))]
     (fn []
       (let [web3 (:web3 @db)
             web3-accounts (when web3
@@ -29,12 +28,14 @@
              (let [accounts (map str/lower-case web3-accounts)
                    addr @address
                    title "Select address"
-                   items (cond->> accounts
-                           (and addr
-                                (not (contains? (set accounts) addr)))
-                           (into [addr])
-                           (not addr)
-                           (into [title]))]
+                   addr-not-in-web3? (and addr (as-> web3-accounts acc
+                                            (map str/lower-case acc)
+                                            (set acc)
+                                            (contains? acc addr)
+                                            (not acc)))
+                   items (cond->> web3-accounts
+                           addr-not-in-web3?  (into [addr])
+                           (not addr) (into [title]))]
                [dropdown {:class "address-input"} 
                 title
                 address

--- a/src/cljs/commiteth/update_address.cljs
+++ b/src/cljs/commiteth/update_address.cljs
@@ -3,6 +3,7 @@
             [commiteth.common :refer [input dropdown]]
             [reagent.core :as r]
             [reagent.crypt :as crypt]
+            [clojure.string :as str]
             [cljs-web3.eth :as web3-eth]))
 
 
@@ -10,7 +11,9 @@
   (let [db (rf/subscribe [:db])
         user (rf/subscribe [:user])
         updating-address (rf/subscribe [:get-in [:updating-address]])
-        address (r/atom @(rf/subscribe [:get-in [:user :address]]))]
+        address (-> @(rf/subscribe [:get-in [:user :address]]) 
+                    str/lower-case 
+                    r/atom)]
     (fn []
       (let [web3 (:web3 @db)
             web3-accounts (when web3
@@ -22,13 +25,12 @@
           [:p "Insert your Ethereum address in hex format."]
           [:div.field
            (if-not (empty? web3-accounts)
-             [dropdown {:class "address-input"} "Select address"
+             [dropdown {:class "address-input"} 
+              "Select address"
               address
-              (vec
-               (for [acc web3-accounts]
-                 acc))]
+              (map str/lower-case web3-accounts)]
              [:div.ui.input.address-input
-              [input address {:placeholder  "0x0000000000000000000000000000000000000000"
+              [input address {:placeholder "0x0000000000000000000000000000000000000000"
                               :auto-complete "off"
                               :auto-correct "off"
                               :spell-check "false"


### PR DESCRIPTION
**Summary**

Following changes are included:

1. Do not preselect a Metamask address if it has not been set earlier by the user.
2. When Metamask is enabled, add a dummy 'Select address' option to the dropdown when no previous addresses were set.
3. Fix user address setting in 'My Payment Details`. Addresses were correctly stored in the DB, but not in re-frame's app-db.

**Status**: Finished.