### PR TITLE
makes the footer always at the bottom.

### DIFF
--- a/src/less/style.less
+++ b/src/less/style.less
@@ -985,6 +985,7 @@
     display: flex;
     justify-content: center;
     margin-top: 20px;
+    margin-bottom: -414px;
 }
 
 


### PR DESCRIPTION
Fix #268 

## Why do this changes:
* The height of the footer is 414px, shown in following attachment:
![image](https://user-images.githubusercontent.com/10568673/36039347-305a5544-0dfd-11e8-80fb-694044cd3cf3.png)
* Stick footer solution refer to [here](https://css-tricks.com/snippets/css/sticky-footer/)