### PR TITLE
Pinned footer to bottom

### DIFF
--- a/src/less/style.less
+++ b/src/less/style.less
@@ -985,6 +985,7 @@
     display: flex;
     justify-content: center;
     margin-top: 20px;
+    margin-bottom: -1em;
 }
 
 


### PR DESCRIPTION
The 'ui.segment' element contains a padding of 1em, which consequently leaves a gap between the footer and browser window. A negative bottom margin of -1em fixes this issue.