### PR TITLE
Footer is not pinned to the bottom fix

### DIFF
--- a/src/cljs/commiteth/core.cljs
+++ b/src/cljs/commiteth/core.cljs
@@ -218,7 +218,7 @@
               [:h3.top-hunters-header "Top 5 hunters"]
               [:div.top-hunters-subheader "All time"]
               [top-hunters]]])]]
-        [footer]]])))
+        ][footer]])))
 
 (secretary/set-config! :prefix "#")
 

--- a/src/cljs/commiteth/core.cljs
+++ b/src/cljs/commiteth/core.cljs
@@ -217,8 +217,8 @@
              [:div.ui.container.top-hunters
               [:h3.top-hunters-header "Top 5 hunters"]
               [:div.top-hunters-subheader "All time"]
-              [top-hunters]]])]]
-        ][footer]])))
+              [top-hunters]]])]]]
+       [footer]])))
 
 (secretary/set-config! :prefix "#")
 

--- a/src/less/style.less
+++ b/src/less/style.less
@@ -984,7 +984,7 @@
     z-index: -1;
     display: flex;
     justify-content: center;
-    margin-top: 20px;
+    margin-top: 10px;
 }
 
 

--- a/src/less/style.less
+++ b/src/less/style.less
@@ -862,6 +862,8 @@
     box-shadow: none;
     border-radius: 0.3em;
 
+    min-height: calc(~"100vh - 400px");
+
     h3 {
         color: #474951;
     }
@@ -984,7 +986,6 @@
     z-index: -1;
     display: flex;
     justify-content: center;
-    margin-top: 10px;
 }
 
 


### PR DESCRIPTION
This commit fixes the footer gap on the bottom. 

Description: 
Semantic UI CSS defines a padding of 1em to the top and bottom of the segment element. Moving the footer outside the dev.ui.vertical.segment would avoid this gap in the bottom. Also, div.commiteth-footer has excessive margin on top (20px) changed this to 10px to maintain the flow of components (optional).

I also see the fix via margin adjustment (#270), this would not solve the issue as seen in the Manage payouts component. Also, it's not advisable to hard code margin based on the height of footer.

Fixes #268