### PR TITLE
remove moment.js dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -42,7 +42,6 @@
                  [cheshire "5.8.0"]
                  [mpg "1.3.0"]
                  [pandect "0.6.1"]
-                 [cljsjs/moment "2.17.1-1"]
                  [org.clojure/tools.nrepl "0.2.13"]
                  [com.cemerick/piggieback "0.2.2"]
                  [jarohen/chime "0.2.2"]

--- a/src/cljs/commiteth/activity.cljs
+++ b/src/cljs/commiteth/activity.cljs
@@ -1,7 +1,7 @@
 (ns commiteth.activity
   (:require [re-frame.core :as rf]
             [reagent.core :as r]
-            [commiteth.common :refer [moment-timestamp
+            [commiteth.common :refer [relative-time
                                       items-per-page
                                       display-data-page
                                       issue-url]]))
@@ -54,7 +54,7 @@
           ^{:key (random-uuid)}
           [:div.balance-badge.token
            (str (subs (str tla) 1) " " balance)])])
-     [:div.time (moment-timestamp updated)]]]])
+     [:div.time (relative-time updated)]]]])
 
 (defn activity-list [{:keys [items item-count page-number total-count] 
                       :as activity-page-data}

--- a/src/cljs/commiteth/bounties.cljs
+++ b/src/cljs/commiteth/bounties.cljs
@@ -1,7 +1,7 @@
 (ns commiteth.bounties
   (:require [reagent.core :as r]
             [re-frame.core :as rf]
-            [commiteth.common :refer [moment-timestamp
+            [commiteth.common :refer [relative-time
                                       display-data-page
                                       items-per-page
                                       issue-url]]
@@ -33,7 +33,7 @@
      [:div.open-bounty-item-content
       [:div.header issue-link]
       [:div.bounty-item-row
-       [:div.time (moment-timestamp updated)]
+       [:div.time (relative-time updated)]
        [:span.bounty-repo-label repo-link]]
 
       [:div.footer-row

--- a/src/cljs/commiteth/common.cljs
+++ b/src/cljs/commiteth/common.cljs
@@ -2,7 +2,7 @@
   (:require [reagent.core :as r]
             [re-frame.core :as rf]
             [clojure.string :as str]
-            [cljsjs.moment]))
+            [goog.date.relative]))
 
 (defn input [val-ratom props]
   (fn []
@@ -23,10 +23,10 @@
                             {:value item}
                             item]))]))
 
-(defn moment-timestamp [time]
-  (let [now (.now js/Date.)
-        js-time (clj->js time)]
-    (.to (js/moment.utc) js-time)))
+(defn relative-time [time]
+  "converts time in milliseconds to a relative form of '1 hour ago'"
+  (let [js-time (clj->js time)]
+    (goog.date.relative/format js-time)))
 
 (defn issue-url [owner repo number]
   (str "https://github.com/" owner "/" repo "/issues/" number))

--- a/src/cljs/commiteth/manage_payouts.cljs
+++ b/src/cljs/commiteth/manage_payouts.cljs
@@ -1,6 +1,6 @@
 (ns commiteth.manage-payouts
   (:require [re-frame.core :as rf]
-            [commiteth.common :refer [moment-timestamp]]))
+            [commiteth.common :refer [relative-time]]))
 
 
 
@@ -33,7 +33,7 @@
        [:div.description (if paid?
                            (str "(paid to " winner-login ")")
                            (str "(" (if merged? "merged" "open") ")"))]
-       [:div.time (moment-timestamp updated)]
+       [:div.time (relative-time updated)]
        [:button.ui.button
         (merge (if (and merged? (not paid?))
                  {}


### PR DESCRIPTION
and replace with goog.date.relative.

Fixes #278 

One aspect of this that I was unable to discern locally was what type the [time] parameter was previously? I assumed milliseconds, but am happy to add additional logic to the extent that it is stored in a different format. 