### PR TITLE
[Fix #291] Fix command to run migrations

### DIFF
--- a/src/clj/commiteth/core.clj
+++ b/src/clj/commiteth/core.clj
@@ -54,10 +54,9 @@ repl-server
   (cond
     (some #{"migrate" "rollback"} args)
     (do
-      (mount/start
-        #'commiteth.config/env
-        #'commiteth.db.core/*db*)
-      (migrations/migrate args (select-keys env [:jdbc-database-url]))
+      (mount/start #'commiteth.config/env)
+      (migrations/migrate args {:database-url (:jdbc-database-url env)})
+      (log/info "Successfully ran" (first args))
       (System/exit 0))
     :else
     (start-app args)))


### PR DESCRIPTION
Fixes #291
Status: Finished

## Summary

This fixes the code in main to run migrations. The issue was that the original code was using `:jdbc-database-url` vs `:database-url`. It now works for both migrations and rollbacks. I've also simplified the components started by mount as we only need to start env and not the db.