### PR TITLE
Introduce Decision Recording w/ GPG Signing Decision

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+doc/decisions

--- a/.adr-dir
+++ b/.adr-dir
@@ -1,1 +1,0 @@
-doc/decisions

--- a/doc/decisions/0001-record-decisions.md
+++ b/doc/decisions/0001-record-decisions.md
@@ -1,0 +1,40 @@
+# 1. Record Decisions
+
+| Date       | Tags    |
+|------------|---------|
+| 2018-02-16 | process |
+
+## Status
+
+Proposed
+
+## Context
+
+We make a lot of decisions during the life of a project and
+documenting those decisions would help new team members and outside
+contributors follow our thinking. It also opens up an opportunity for
+constructive criticism around those decisions which will result
+in better decision making.
+
+We want to develop a product in the open. Opening up our decision making process for outside contributors is an important part in providing the opportunity to take ownership and impact the project in non-trivial ways.
+
+Recording decisions will also be a useful form of documentation in general as it does not get out of date. All that's documented is that a decision has been made at a certain point in time.
+
+## Decision
+
+We will adopt a format similar to [Architecture Decision
+Records](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) (ADR)
+to propose and document notable decisions. In contrast to ADRs we will try to embrace this tool for more than just architectural concerns. Decisions regarding development practices and product direction are just as important.
+
+What decisions are notable and which are not is left to common-sense and informal consensus among the team.
+
+Decisions may be proposed and discussed informally, should however eventually end up — with all relevant discussion summarized — in the `doc/decisions/` directory of this repository.
+
+Decisions are numbered to have a clear identifier.
+
+## Consequences
+
+- We need to document that we record decisions this way and where people can find those documents.
+- We should probably provide some pointers around tooling to better work with decision records. [`adr-tools`](https://github.com/npryce/adr-tools) comes to mind.
+- Since we deviate from ADRs a bit (we document more than architecture-related decisions) we might need to provide different templates than what comes with tools like `adr-tools` by default.
+  A template like this may also be useful to guide decision authors to provide appropriate context.

--- a/doc/decisions/0002-sign-commits-with-gpg.md
+++ b/doc/decisions/0002-sign-commits-with-gpg.md
@@ -17,6 +17,11 @@ Naturally security is a concern that should be taken into consideration.
 Currently an attacker might get access to an account of a team member
 and pose as that developer, merging PRs and pushing changes.
 
+Status.im as a company is also encouraging the use of GPG signing and
+has a Pull Request check in place on Github. This check will mark PRs
+as failing if the commits come from an organization member and have not
+been GPG-signed.
+
 ## Decision
 
 In order to verify that commits in the repository are actually authored by the specified
@@ -28,6 +33,9 @@ a Git commit and make workflows like deploying on push safer.
 It also introduces some complexity because contributors who want to sign
 their commits need to set up the appropriate tooling. Due to that we will
 not require outside contributors to sign their commits for now.
+
+Adopting GPG signing for contributors will also make our PR checks pass
+allowing us to more easily discern actually broken and working PRs.
 
 ## Consequences
 

--- a/doc/decisions/0002-sign-commits-with-gpg.md
+++ b/doc/decisions/0002-sign-commits-with-gpg.md
@@ -1,0 +1,44 @@
+# 2. Sign Commits With GPG
+
+| Date       | Tags              |
+|------------|-------------------|
+| 2018-02-16 | process, security |
+
+
+## Status
+
+Proposed
+
+## Context
+
+OpenBounty is a system which has value flowing through it.
+Naturally security is a concern that should be taken into consideration.
+
+Currently an attacker might get access to an account of a team member
+and pose as that developer, merging PRs and pushing changes.
+
+## Decision
+
+In order to verify that commits in the repository are actually authored by the specified
+author we adopt [GPG signing of Git commits](https://git-scm.com/book/id/v2/Git-Tools-Signing-Your-Work).
+
+This will allow us to verify authenticity of the author information saved in
+a Git commit and make workflows like deploying on push safer.
+
+It also introduces some complexity because contributors who want to sign
+their commits need to set up the appropriate tooling. Due to that we will
+not require outside contributors to sign their commits for now.
+
+## Consequences
+
+GPG signing is only making things safer if we have a trusted way of
+exchanging public keys. In the scenario outlined above a user who got access
+to GitHub could simply upload an additional key.
+
+This is currently a work-in-progress within the wider Status organization
+and we'll have to wait to see what comes out of that.
+
+## Appendix
+
+- [GitHub's instructions for setting up GPG signing](https://help.github.com/articles/signing-commits-using-gpg/)
+- More discussion around the usefulness of GPG signing in [issue #285](https://github.com/status-im/open-bounty/issues/285)

--- a/doc/decisions/README.md
+++ b/doc/decisions/README.md
@@ -1,0 +1,14 @@
+# Decisions
+
+We record decisions. More context on why and how we do that can be found in [DR-0001](doc/decisions/0001-record-decisions.md).
+
+The remainder of this document is intended to document tooling around this process.
+
+### Utilities to Write Decision Records
+
+- `doc/decisions/templates/template.md` - contains a template for a decision record.
+- When recording a decision follow the established file name format
+  `XXXX-some-title.md` where XXXX is the ever increasing count of decisions
+  we've made.
+
+> More to come. Perhaps document how we can use [`adr-tools`](https://github.com/npryce/adr-tools)

--- a/doc/decisions/templates/template.md
+++ b/doc/decisions/templates/template.md
@@ -9,6 +9,8 @@
 
 STATUS
 
+Common states: proposed, accepted, rejected, deprecated, superseded
+
 ## Context
 
 Describe the context in which the decision has been made.

--- a/doc/decisions/templates/template.md
+++ b/doc/decisions/templates/template.md
@@ -1,0 +1,29 @@
+# NUMBER. TITLE
+
+| Date | Tags |
+|---|---|
+| DATE | e.g: architecture, database |
+
+
+## Status
+
+STATUS
+
+## Context
+
+Describe the context in which the decision has been made.
+Some questions that should give some ideas what to write here:
+
+- What problems have you encountered that this decision impacts?
+- What is the current state of things that are related to this decision?
+
+## Decision
+
+Describe your decision.
+
+- In what ways does it solve the aforementioned problems or improves something?
+- What tradeoffs does this decision make?
+
+## Consequences
+
+Expand on tradeoffs and other side-effects of this decision.


### PR DESCRIPTION
I've mentioned my appreciation of decision reocrds for documentation purposes
before and so this is a proposal to use them as part of Open Bounty.

The motivation to use decision records is in [`0001-recording-decisions.md`](https://github.com/status-im/open-bounty/blob/8a008c144d31ad88acda350ba2cd922bd92be491/doc/decisions/0001-record-decisions.md)
and a first non-meta decision can be found in [`0002-sign-commits-with-gpg.md`](https://github.com/status-im/open-bounty/blob/doc/gpg-decision/doc/decisions/0002-sign-commits-with-gpg.md).