### PR TITLE
[Fix #306] Add support for reloading code

### DIFF
--- a/env/dev/clj/user.clj
+++ b/env/dev/clj/user.clj
@@ -1,15 +1,34 @@
 (ns user
   (:require [mount.core :as mount]
-            [commiteth.figwheel :refer [start-fw stop-fw cljs]]))
+            [commiteth.figwheel :refer [start-fw stop-fw cljs]]
+            [clojure.tools.namespace.repl :as repl]))
 
-(defn start []
+(repl/set-refresh-dirs "src" "dev" "test")
+
+(defn start
+  "Start all the application components"
+  []
   (require 'commiteth.core)
   (mount/start-without (ns-resolve 'commiteth.core 'repl-server)))
 
-(defn stop []
+(defn stop
+  "Stop all the application components"
+  []
   (require 'commiteth.core)
   (mount/stop-except (ns-resolve 'commiteth.core 'repl-server)))
 
+(defn refresh
+  "Reload the latest namespace definitions"
+  []
+  (repl/refresh))
+
+(defn reset
+  "Restart application after refreshing namespace definitions"
+  []
+  (stop)
+  (repl/refresh :after 'user/start))
+
 (defn restart []
+  "Restart without refreshing namespace definitions"
   (stop)
   (start))

--- a/project.clj
+++ b/project.clj
@@ -124,6 +124,7 @@
                             [binaryage/devtools "0.9.7"]
                             [figwheel-sidecar "0.5.14"]
                             [org.clojure/tools.nrepl "0.2.13"]
+                            [org.clojure/tools.namespace "0.2.11"]
                             [com.cemerick/piggieback "0.2.2"]
                             [sablono "0.8.1"]]
            :plugins        [[com.jakemccrary/lein-test-refresh "0.14.0"]


### PR DESCRIPTION
Fixes: #306 
Status: Finished

This adds `clojure.tools.namespace` to be able to reload code. It's a better alternative to `reload-all` as outlined [here](https://github.com/clojure/tools.namespace#reloading-code-motivation) and [here](https://github.com/tolitius/mount#the-importance-of-being-reloadable).

If you run:
- `refresh` will reload all changed namespaces with their latest definition.
- `reset` will stop the current system first, then refresh, and restart the
dependencies.