### PR TITLE
fix relative time display for long-ago dates

### DIFF
--- a/src/cljs/commiteth/activity.cljs
+++ b/src/cljs/commiteth/activity.cljs
@@ -1,7 +1,7 @@
 (ns commiteth.activity
   (:require [re-frame.core :as rf]
             [reagent.core :as r]
-            [commiteth.common :refer [relative-time
+            [commiteth.common :refer [human-time
                                       items-per-page
                                       display-data-page
                                       issue-url]]))
@@ -54,7 +54,7 @@
           ^{:key (random-uuid)}
           [:div.balance-badge.token
            (str (subs (str tla) 1) " " balance)])])
-     [:div.time (relative-time updated)]]]])
+     [:div.time (human-time updated)]]]])
 
 (defn activity-list [{:keys [items item-count page-number total-count] 
                       :as activity-page-data}

--- a/src/cljs/commiteth/bounties.cljs
+++ b/src/cljs/commiteth/bounties.cljs
@@ -1,7 +1,7 @@
 (ns commiteth.bounties
   (:require [reagent.core :as r]
             [re-frame.core :as rf]
-            [commiteth.common :refer [relative-time
+            [commiteth.common :refer [human-time
                                       display-data-page
                                       items-per-page
                                       issue-url]]
@@ -33,7 +33,7 @@
      [:div.open-bounty-item-content
       [:div.header issue-link]
       [:div.bounty-item-row
-       [:div.time (relative-time updated)]
+       [:div.time (human-time updated)]
        [:span.bounty-repo-label repo-link]]
 
       [:div.footer-row

--- a/src/cljs/commiteth/common.cljs
+++ b/src/cljs/commiteth/common.cljs
@@ -2,7 +2,9 @@
   (:require [reagent.core :as r]
             [re-frame.core :as rf]
             [clojure.string :as str]
-            [goog.date.relative]))
+            [goog.date.relative]
+            [goog.i18n.DateTimePatterns :as DateTimePatterns])
+  (:import (goog.i18n DateTimeFormat)))
 
 (defn input [val-ratom props]
   (fn []
@@ -24,10 +26,20 @@
                               :disabled (= item title)} 
                      item])]))
 
-(defn relative-time [time]
-  "converts time in milliseconds to a relative form of '1 hour ago'"
-  (let [js-time (clj->js time)]
-    (goog.date.relative/format js-time)))
+(def ^:private long-ago-fmt
+  (DateTimeFormat. DateTimePatterns/MONTH_DAY_FULL))
+
+(defn human-time [date]
+  "Shows a given date in a human-friendly way. For dates less than
+   two weeks ago this means a relative '3 hours ago' kind of thing.
+   For dates longer ago we return 'January 01'."
+  (let [ms       (.getTime date)
+        relative (goog.date.relative/format ms)]
+    ;; Dates older than 2 weeks will not be shown as relative
+    ;; https://github.com/google/closure-library/blob/99d7fa323f4c9e35ce7a97ea3cb08fc1d97d9e92/closure/goog/date/relative.js#L206
+    (if-not (empty? relative)
+      relative
+      (goog.date.relative/formatDay ms #(.format long-ago-fmt %)))))
 
 (defn issue-url [owner repo number]
   (str "https://github.com/" owner "/" repo "/issues/" number))

--- a/src/cljs/commiteth/manage_payouts.cljs
+++ b/src/cljs/commiteth/manage_payouts.cljs
@@ -1,6 +1,6 @@
 (ns commiteth.manage-payouts
   (:require [re-frame.core :as rf]
-            [commiteth.common :refer [relative-time]]))
+            [commiteth.common :refer [human-time]]))
 
 
 
@@ -33,7 +33,7 @@
        [:div.description (if paid?
                            (str "(paid to " winner-login ")")
                            (str "(" (if merged? "merged" "open") ")"))]
-       [:div.time (relative-time updated)]
+       [:div.time (human-time updated)]
        [:button.ui.button
         (merge (if (and merged? (not paid?))
                  {}


### PR DESCRIPTION
Fix for a problem reported by @churik where relative dates were not shown.

This happens with dates older than 2 weeks. I changed the code so that a human-friendly date is displayed instead of a relative statement. 