### PR TITLE
Disable UPDATE button if address string is empty

### DIFF
--- a/src/cljs/commiteth/update_address.cljs
+++ b/src/cljs/commiteth/update_address.cljs
@@ -65,6 +65,7 @@
            (merge {:on-click
                    #(rf/dispatch [:save-user-fields {:address @address
                                                      :is_hidden_in_hunters @hidden}])
+                   :disabled (str/blank? @address)
                    :class (str "ui button small update-address-button"
                                (when @updating-user
                                  " busy loading"))})


### PR DESCRIPTION
**Problem**: if an UPDATE button is clicked when address string is empty (does not matter if Metamask is enabled or not), Schema will complain about failing `Str` check, and this does not look good from user's perspective.

**Solution**: disable UPDATE button if address string is empty.