### PR TITLE
fix #301: add basic stats to manage payouts screen

### DIFF
--- a/resources/templates/home.html
+++ b/resources/templates/home.html
@@ -65,6 +65,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
  src="https://www.facebook.com/tr?id=293089407869419&ev=PageView&noscript=1"
 /></noscript>
 <link href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.1.8/semantic.min.css" rel="stylesheet" type="text/css" />
+<link href="https://unpkg.com/tachyons@4.9.1/css/tachyons.min.css" rel="stylesheet" type="text/css" />
 <link href="/css/style.css?v={{commiteth-version}}" rel="stylesheet" type="text/css" />
 <script type="text/javascript" src="/js/app.js?v={{commiteth-version}}"></script>
 <script>

--- a/src/cljs/commiteth/common.cljs
+++ b/src/cljs/commiteth/common.cljs
@@ -135,4 +135,10 @@
             [:div.page-nav-text [:span (str "Page " page-number " of " page-count)]]
             [draw-page-numbers page-number page-count container-element]]])))
 
+(defn usd-string
+  "Turn a given float into a USD currency string based on the browsers locale setting.
 
+  A more complex and customizable approach can be found in goog.i18n.NumberFormat:
+  https://google.github.io/closure-library/api/goog.i18n.NumberFormat.html"
+  [usd-float]
+  (.toLocaleString usd-float js/navigator.language #js {:style "currency" :currency "USD"}))

--- a/src/cljs/commiteth/manage_payouts.cljs
+++ b/src/cljs/commiteth/manage_payouts.cljs
@@ -57,6 +57,19 @@
                        (:claims bounty))]
             [claim-card bounty claim]))))
 
+(defn bounty-stats [{:keys [paid unpaid]}]
+  (let [sum-dollars (fn [bounties]
+                      (reduce + (map #(js/parseFloat (:value_usd %)) bounties)))]
+    [:div.cf.pv4
+     [:div.fl.w-50.tc
+      [:div.ttu.tracked "Open"]
+      [:div.f2.pa2 "$" (sum-dollars unpaid)]
+      [:div (count unpaid) " bounties"]]
+
+     [:div.fl.w-50.tc
+      [:div.ttu.tracked "Paid"]
+      [:div.f2.pa2 "$" (sum-dollars paid)]
+      [:div (count paid) " bounties"]]]))
 
 (defn manage-payouts-page []
   (let [owner-bounties (rf/subscribe [:owner-bounties])
@@ -68,15 +81,16 @@
           [:div.ui.text.loader "Loading"]]]
         (let [web3 (.-web3 js/window)
               bounties (vals @owner-bounties)
-              unpaid? #(empty? (:payout_hash %))
-              paid? #(not-empty (:payout_hash %))
-              unpaid-bounties (filter unpaid? bounties)
-              paid-bounties (filter paid? bounties)]
+              paid?  :payout_hash
+              unpaid-bounties (filter (complement paid?) bounties)
+              paid-bounties   (filter paid? bounties)]
           [:div.ui.container
            (when (nil? web3)
              [:div.ui.warning.message
               [:i.warning.icon]
               "To sign off claims, please view Status Open Bounty in Status, Mist or Metamask"])
+           [bounty-stats {:paid paid-bounties
+                          :unpaid unpaid-bounties}]
            [:h3 "New claims"]
            [claim-list unpaid-bounties]
            [:h3 "Old claims"]

--- a/src/cljs/commiteth/manage_payouts.cljs
+++ b/src/cljs/commiteth/manage_payouts.cljs
@@ -58,13 +58,13 @@
             [claim-card bounty claim]))))
 
 (defn bounty-stats [{:keys [paid unpaid]}]
-  [:div.cf.pv4
-   [:div.fl.w-50.tc
+  [:div.cf
+   [:div.fl-ns.w-50-ns.tc.pv4
     [:div.ttu.tracked "Open"]
     [:div.f2.pa2 (common/usd-string (:combined-usd-value unpaid))]
     [:div (:count unpaid) " bounties"]]
 
-   [:div.fl.w-50.tc
+   [:div.fl-ns.w-50-ns.tc.pv4
     [:div.ttu.tracked "Paid"]
     [:div.f2.pa2 (common/usd-string (:combined-usd-value paid))]
     [:div (:count paid) " bounties"]]])

--- a/src/cljs/commiteth/subscriptions.cljs
+++ b/src/cljs/commiteth/subscriptions.cljs
@@ -68,7 +68,26 @@
 (reg-sub
   :owner-bounties
   (fn [db _]
-    (:owner-bounties db)))
+    (->> (for [[id bounty] (:owner-bounties db)]
+           ;; TODO(martinklepsch) we might want to consider using a
+           ;; special prefix or namespace for derived properties that
+           ;; are added to domain records like this
+           ;; e.g. `derived/paid?`
+           [id (assoc bounty :paid? (boolean (:payout_hash bounty)))])
+         (into {}))))
+
+(reg-sub
+ :owner-bounties-stats
+ :<- [:owner-bounties]
+ (fn [owner-bounties _]
+   (let [sum-dollars (fn sum-dollars [bounties]
+                       (reduce + (map #(js/parseFloat (:value_usd %)) bounties)))
+         {:keys [paid unpaid]} (group-by #(if (:paid? %) :paid :unpaid)
+                                         (vals owner-bounties))]
+     {:paid {:count (count paid)
+             :combined-usd-value (sum-dollars paid)}
+      :unpaid {:count (count unpaid)
+               :combined-usd-value (sum-dollars unpaid)}})))
 
 (reg-sub
   :pagination


### PR DESCRIPTION
Fixes #301: Basic Dashboard reports.

This PR adds some basic stats to the manage payouts screen:

<img width="961" alt="screen shot 2018-02-20 at 17 55 41" src="https://user-images.githubusercontent.com/97496/36437484-685089d8-1667-11e8-8605-9a493416444a.png">

- I manually made myself owner by changing the `owner` and `user_id` columns in the database. It's very possible that I missed something and my database is now "corrupted". #312 would be nice for this.
- I added a new CSS lib [Tachyons](http://tachyons.io/) which I've worked a lot with in the past and which I think might be a good way to tackle #209 (Refactor CSS Usage). Tachyons can be a bit weird at the beginning but I will annotate the code in this PR to explain how things are done and provide links to some useful tools. I hope we can slowly transition components as needed.