### PR TITLE
Do not invoke build-contracts when running lein dev profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ Launch the following command in a separate shell:
 lein less auto
 ```
 
+### Solidity compilation
+Invoke `build-contracts` Leiningen task to compile Solidity files into Java classes:
+```
+lein build-contracts
+```
+
 ### Clojure app without REPL
 Launch following commands each in its own shell:
 
@@ -146,7 +152,10 @@ To create a standalone uberjar:
 lein uberjar
 ```
 
-This creates `target/uberjar/commiteth-<git-sha>.jar`
+This creates `target/uberjar/commiteth.jar`. You can run it with the following command from within project root:
+```
+java -Dconf=<path_to_config.edn> -jar target/uberjar/commiteth.jar
+```
 
 
 ## Testing

--- a/project.clj
+++ b/project.clj
@@ -83,13 +83,12 @@
 
   :uberjar-exclusions [#"public/README.md" #"public/cards.html"]
   :clean-targets ^{:protect false}
-  [:target-path [:cljsbuild :builds :app :compiler :output-dir] [:cljsbuild :builds :app :compiler :output-to]]
+  [:target-path :java-source-paths [:cljsbuild :builds :app :compiler :output-dir] [:cljsbuild :builds :app :compiler :output-to]]
   :figwheel
   {:http-server-root "public"
    :nrepl-port       7002
    :css-dirs         ["resources/public/css"]
    :nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}
-
 
   :profiles
   {:uberjar       {:jvm-opts ["-server" "-Dconf=config-prod.edn"]
@@ -143,7 +142,6 @@
                :optimizations :none
                :pretty-print  true}}]}
 
-           :prep-tasks     ["build-contracts" "javac"]
            :doo            {:build "test"}
            :source-paths   ["env/dev/clj" "test/clj"]
            :resource-paths ["env/dev/resources"]


### PR DESCRIPTION
**Problem**: `build-contracts` takes some time to complete, and by default it is always invoked during `lein repl` or `lein run`.

**Solution**: invoke it separately. Specify this in the README.