### PR TITLE
swap secretary with bide, move routing into extra ns

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
                   :exclusions [joda-time]]
                  [re-frame "0.10.2"]
                  [cljs-ajax "0.7.2"]
-                 [secretary "1.2.3"]
+                 [funcool/bide "1.6.0"]
                  [reagent-utils "0.2.1"]
                  [reagent "0.7.0"]
                  [org.clojure/clojurescript "1.9.946"]

--- a/src/cljs/commiteth/core.cljs
+++ b/src/cljs/commiteth/core.cljs
@@ -53,7 +53,7 @@
                               [:a
                                (merge props
                                       (if (keyword? target)
-                                        {:on-click #(rf/dispatch [target])}
+                                        {:on-click #(commiteth.routes/nav! target)}
                                         {:href target}))
                                caption]]))]]))
 
@@ -66,7 +66,7 @@
         [:div.ui.container.user-component
          [user-dropdown
           @user
-          [[:update-address "My Payment Details" {}]
+          [[:settings "My Payment Details" {}]
            ["/logout" "Sign Out" {:class "logout-link"}]]
           mobile?]]
         [:a.ui.button.small.login-button {:href js/authorizeUrl} (str "LOG IN"
@@ -207,7 +207,7 @@
               :bounties       [bounties-page]
               :repos          [repos-page]
               :manage-payouts [manage-payouts-page]
-              :update-address [update-address-page]
+              :settings       [update-address-page]
               :usage-metrics  [usage-metrics-page])]]
           (when (show-top-hunters?)
             [:div.five.wide.column.computer.only

--- a/src/cljs/commiteth/handlers.cljs
+++ b/src/cljs/commiteth/handlers.cljs
@@ -312,12 +312,6 @@
                              (:status-text response)))]}))
 
 
-(reg-event-fx
- :update-address
- (fn [{:keys [db]} [_]]
-   {:db db
-    :dispatch [:set-active-page :update-address]}))
-
 (reg-event-db
  :update-user
  (fn [db [_ fields]]

--- a/src/cljs/commiteth/routes.cljs
+++ b/src/cljs/commiteth/routes.cljs
@@ -7,7 +7,7 @@
                 ["/activity"       :activity]
                 ["/repos"          :repos]
                 ["/manage-payouts" :manage-payouts]
-                ["/update-address" :update-address]
+                ["/settings"       :settings]
                 ["/usage-metrics"  :usage-metrics]]))
 
 (defn on-navigate

--- a/src/cljs/commiteth/routes.cljs
+++ b/src/cljs/commiteth/routes.cljs
@@ -1,0 +1,25 @@
+(ns commiteth.routes
+  (:require [bide.core :as bide]
+            [re-frame.core :as rf]))
+
+(defonce router
+  (bide/router [["/"               :bounties]
+                ["/activity"       :activity]
+                ["/repos"          :repos]
+                ["/manage-payouts" :manage-payouts]
+                ["/update-address" :update-address]
+                ["/usage-metrics"  :usage-metrics]]))
+
+(defn on-navigate
+  "A function which will be called on each route change."
+  [name params query]
+  (println "Route change to: " name params query)
+  (rf/dispatch [:set-active-page name]))
+
+(defn setup-nav! []
+  (bide/start! router {:default     :bounties
+                       :on-navigate on-navigate}))
+
+(defn nav! [route-id]
+  (bide/navigate! router route-id {}))
+


### PR DESCRIPTION
We've been using secretary but it hasn't been integrated into the codebase very
well. For instance clicking on "Activity" in the menu would not change the url
to include the `#/activity` bit.

This PR fixes that by replacing Secretary with [bide](https://github.com/funcool/bide).
I hope in the future we can extend our usage of URL routing to support page numbers and
other parameters (e.g. sorting) (see #355). This will make it easier for people to share links to
different views of the application.