### PR TITLE
[FIX #355] persist bounty filter to query string

### DIFF
--- a/src/cljs/commiteth/routes.cljs
+++ b/src/cljs/commiteth/routes.cljs
@@ -14,12 +14,17 @@
   "A function which will be called on each route change."
   [name params query]
   (println "Route change to: " name params query)
-  (rf/dispatch [:set-active-page name]))
+  (rf/dispatch [:set-active-page name params query]))
 
 (defn setup-nav! []
   (bide/start! router {:default     :bounties
                        :on-navigate on-navigate}))
 
-(defn nav! [route-id]
-  (bide/navigate! router route-id {}))
+(defn nav!
+  ([route-id]
+   (nav! route-id nil))
+  ([route-id params]
+   (nav! route-id params nil))
+  ([route-id params query]
+   (bide/navigate! router route-id params query)))
 

--- a/src/cljs/commiteth/subscriptions.cljs
+++ b/src/cljs/commiteth/subscriptions.cljs
@@ -179,7 +179,7 @@
                          (mapcat keys)
                          (filter identity)
                          set)]
-      (into #{"ETH"} token-ids))))
+      (into #{:ETH} token-ids))))
 
 (reg-sub
   ::filtered-and-sorted-open-bounties


### PR DESCRIPTION
fixes #355 

Persist bounty filters to query string using bide query params as described in #355.

This needs additional testing, as I could not get the github integration to work locally yet.

The filter UI works as expected, but without actual bounties in the DB it's hard to tell if it really works.

@martinklepsch do you think you could take a look at this?