### PR TITLE
Quick dev login bypassing OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Key | Description
 --- | ---
 dev | Currently specifies whether Swagger UI endpoints should be added to routes
 port | HTTP port for the Ring web app
+dev-login | Local development only. Set it to GitHub name of your dev user in order to login into the system bypassing OAuth. `server-address` has to be then correspondingly set to your localhost address.
 nrepl-port | nREPL port for development
 jdbc-database-url | PostgreSQL database URL. For instance, URL to local db would be `jdbc:postgresql://localhost/commiteth?user=commiteth&password=commiteth`
 server-address | URL and port of local server that can be resolved from public internet. It will be used as a redirect URI during GitHub OAuth authorization process

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -43,6 +43,13 @@ SELECT *
 FROM users
 WHERE id = :id;
 
+-- :name get-user-by-login :? :1
+-- :doc retrieve a user given GitHub login.
+SELECT *
+FROM users
+WHERE login = :login;
+
+
 -- :name get-repo-owner :? :1
 SELECT *
 FROM users u, repositories r

--- a/src/clj/commiteth/db/users.clj
+++ b/src/clj/commiteth/db/users.clj
@@ -21,6 +21,11 @@
   (jdbc/with-db-connection [con-db *db*]
     (db/get-user con-db {:id user-id})))
 
+(defn get-user-by-login
+  [login]
+  (jdbc/with-db-connection [con-db *db*]
+    (db/get-user-by-login con-db {:login login})))
+
 (defn exists?
   [user-id]
   (jdbc/with-db-connection [con-db *db*]

--- a/src/clj/commiteth/routes/home.clj
+++ b/src/clj/commiteth/routes/home.clj
@@ -23,7 +23,10 @@
                               :on-testnet? (env :on-testnet)}))
 
 (defn landing-page []
-  (layout/render "index.html" {:authorize-url (github/signup-authorize-url)}))
+  (layout/render "index.html" 
+                 {:authorize-url (if (env :dev-login)
+                                   (str (env :server-address) "/callback_dev")
+                                   (github/signup-authorize-url))}))
 
 (defn welcome-page []
   (layout/render "welcome.html"))


### PR DESCRIPTION
Sometimes it is desirable to fix/develop a feature that does not require any of GitHub integration. Keeping `ngrok` open in order to login into OpenBounty app can slowdown the network connection needlessly in those cases.

This PR adds support for `:dev-login` key in configuration that should be set to your GitHub user name for this feature to work. Clicking on `LOG IN` will then bypass OAuth and redirect to your `server-address` which should be set to `localhost`.