### PR TITLE
Add less to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ WORKDIR /root/
 RUN apt-get update
 RUN apt-get -y install xvfb
 RUN apt-get -y install wkhtmltopdf
+RUN apt-get -y install less
 
 COPY --from=builder /usr/src/app/target/uberjar/commiteth.jar .
 COPY html2png.sh .


### PR DESCRIPTION
Add `less` to Dockerfile. Simplifies debugging when e.g. it is necessary to view app logs inside container.