### PR TITLE
Some watch-token improvements

### DIFF
--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -348,6 +348,7 @@ WHERE issue_id = :issue_id;
 -- :doc issues with a pending watch transaction
 SELECT
 issue_id,
+contract_address,
 watch_hash
 FROM issues
 WHERE watch_hash IS NOT NULL;

--- a/src/clj/commiteth/routes/services.clj
+++ b/src/clj/commiteth/routes/services.clj
@@ -171,6 +171,8 @@
                 (do
                   (log/debug "/usage-metrics" user)
                   (ok (usage-metrics/usage-metrics-by-day))))
+           (POST "/watchTokens" {:keys [params]}
+                 (ok (bounties/watch-tokens (:issue_id params) (:contract_address params))))
 
            (context "/user" []
 

--- a/src/cljs/commiteth/manage_payouts.cljs
+++ b/src/cljs/commiteth/manage_payouts.cljs
@@ -38,7 +38,7 @@
         (merge (if (and merged? (not paid?))
                  {}
                  {:disabled true})
-               {:on-click #(rf/dispatch [:confirm-payout claim])}
+               {:on-click #(rf/dispatch [:watch-and-confirm-payout claim])}
                (when (and (or confirming? bot-confirm-unmined?)
                           merged?)
                  {:class "busy loading" :disabled true}))


### PR DESCRIPTION
- Re-execute watch if max attempt count exceeded;
- block multiple execute tx attempts in case when there are funds still on account (probably due to missing watch invocation);
- invoke watch synchronously prior to confirming transactions