### PR TITLE
update-repo-state should call db/update-repo-state, not db/update-repo-name

### DIFF
--- a/src/clj/commiteth/db/repositories.clj
+++ b/src/clj/commiteth/db/repositories.clj
@@ -34,7 +34,7 @@
 (defn update-repo-state
   [repo-id repo-state]
   (jdbc/with-db-connection [con-db *db*]
-    (db/update-repo-name con-db {:repo_id repo-id
+    (db/update-repo-state con-db {:repo_id repo-id
                                  :repo_state repo-state})))
 (defn get-repo
   "Get a repo from DB given it's full name (owner/repo-name)"


### PR DESCRIPTION
I came across this while tailing the logs in order to create a new issue. I've been mucking with my local postgres so much that it seems this is unlikely to be hit by anyone else who isn't reinstalling the app on their repository for the "first" time. 

## example of error message
2018-04-11 12:51:03,387 [XNIO-1 task-21] ERROR commiteth.routes.webhooks - exception when enabling repo #error {
 :cause Parameter Mismatch: :repo_name parameter data not found.