### PR TITLE
WIP: allow posting of issue comments from github account with2FA enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ github-client-id | Related to OAuth. Copied from GitHub account Settings->Develo
 github-client-secret | Related to OAuth. Copied from GitHub account Settings->Developer settings->OAuth Apps
 github-user | GitHub username for bot account. It is used for posting bounty comments
 github-password | GitHub password for bot account
+github-token | GitHub token for bot account. (see
+https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/ for details)
 webhook-secret | Secret string to be used when creating a GitHub App
 user-whitelist | Set of GitHub user/org IDs to be whitelisted. E.g. `#{"status-im" "your_org"}`
 testnet-token-data | Token data map, useful if there are Geth connectivity problems


### PR DESCRIPTION
My local bot account was blocked from commenting on a labelled issue with a bounty by github's api. Per Github's documentation: https://developer.github.com/v3/auth/#working-with-two-factor-authentication, this pull request aims to set the X-GitHub-OTP header. I am pretty sure it should come from a personal access token created through github (instructions here: https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) rather than being one of the access tokens we are receiving back within the app itself. Although suggestions are welcome around process here :)

<blockquote><div><strong><a href="https://developer.github.com/v3/auth/#working-with-two-factor-authentication">Other Authentication Methods | GitHub Developer Guide</a></strong></div></blockquote>
<blockquote><div><strong><a href="https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/">Creating a personal access token for the command line - User Documentation</a></strong></div><div>You can create a personal access token and use it in place of a password when performing Git operations over HTTPS with Git on the command line or the API.
…</div></blockquote>