### PR TITLE
Throw exception if about to use an old nonce

### DIFF
--- a/src/clj/commiteth/bounties.clj
+++ b/src/clj/commiteth/bounties.clj
@@ -23,7 +23,7 @@
 (defn deploy-contract [owner owner-address repo issue-id issue-number]
   (if (empty? owner-address)
     (log/errorf "issue %s: Unable to deploy bounty contract because repo owner has no Ethereum addres" issue-id)
-    (do
+    (try
       (log/infof "issue %s: Deploying contract to %s" issue-id owner-address)
       (if-let [transaction-hash (multisig/deploy-multisig owner-address)]
         (do
@@ -36,7 +36,8 @@
             (log/infof "issue %s: post-deploying-comment response: %s" issue-id resp)
             (issues/update-comment-id issue-id comment-id))
           (issues/update-transaction-hash issue-id transaction-hash))
-        (log/errorf "issue %s Failed to deploy contract to %s" issue-id owner-address)))))
+        (log/errorf "issue %s Failed to deploy contract to %s" issue-id owner-address))
+      (catch Exception ex (log/errorf ex "issue %s: deploy-contract exception" issue-id)))))
 
 (defn add-bounty-for-issue [repo repo-id issue]
   (let [{issue-id     :id

--- a/src/clj/commiteth/eth/core.clj
+++ b/src/clj/commiteth/eth/core.clj
@@ -65,7 +65,6 @@
         (if (= nonce @current-nonce)
           (throw (Exception. (str "Attempting to create transaction with the same nonce: " nonce)))
           (swap! current-nonce (constantly nonce)))
-        (log/info "Current nonce:" nonce)
         nonce))))
 
 (defn get-signed-tx [gas-price gas-limit to data]


### PR DESCRIPTION
`get-signed-tx` is used by:
1. `multisig/create-new`
2. `multisig/watch-token`
3. `multisig/send-all`

If an exception is thrown, then
1. `create-new` (contract deployment) will be retried by `deploy-pending-contracts` scheduler thread
2. `watch-token` will be retried by `update-bounty-token-balances` scheduler thread
3. `send-all` will be retried by `self-sign-bounty` scheduler thread