### PR TITLE
fix #399: track each internal transaction and associated nonce

### DIFF
--- a/src/clj/commiteth/bounties.clj
+++ b/src/clj/commiteth/bounties.clj
@@ -25,7 +25,8 @@
     (log/errorf "issue %s: Unable to deploy bounty contract because repo owner has no Ethereum addres" issue-id)
     (try
       (log/infof "issue %s: Deploying contract to %s" issue-id owner-address)
-      (if-let [transaction-hash (multisig/deploy-multisig owner-address)]
+      (if-let [transaction-hash (multisig/deploy-multisig {:owner owner-address
+                                                           :internal-tx-id (str "contract-github-issue-" issue-id)})]
         (do
           (log/infof "issue %s: Contract deployed, transaction-hash: %s" issue-id transaction-hash)
           (let [resp (github/post-deploying-comment owner

--- a/src/clj/commiteth/eth/core.clj
+++ b/src/clj/commiteth/eth/core.clj
@@ -73,13 +73,15 @@
                                   DefaultBlockParameterName/LATEST)
                                  sendAsync
                                  get
-                                 getTransactionCount)]
+                                 getTransactionCount)
+              nonce          (if (contains? nonces web3j-tx-count)
+                               (inc (max nonces))
+                               web3j-tx-count)]
           ;; TODO this is a memory leak since tracking state is never pruned
           ;; Since we're not doing 1000s of transactions every day yet we can
           ;; probably defer worrying about this until a bit later
-          (if (contains? nonces web3j-tx-count)
-            (swap! state assoc internal-tx-id (inc (max nonces)))
-            (swap! state assoc internal-tx-id web3j-tx-count))))))
+          (swap! state assoc internal-tx-id nonce)
+          nonce))))
 
 (def nonce-tracker
   (->NonceTracker (atom {})))

--- a/src/clj/commiteth/eth/core.clj
+++ b/src/clj/commiteth/eth/core.clj
@@ -219,9 +219,10 @@
 (defn estimate-gas
   [from to value & [params]]
   (let [geth-estimate (eth-rpc
-                       "eth_estimateGas" [(merge params {:from  from
-                                                         :to    to
-                                                         :value value})])
+                       {:method "eth_estimateGas"
+                        :params [(merge params {:from  from
+                                                :to    to
+                                                :value value})]})
         adjusted-gas (adjust-gas-estimate geth-estimate)]
 
     (log/debug "estimated gas (geth):" geth-estimate)

--- a/src/clj/commiteth/eth/core.clj
+++ b/src/clj/commiteth/eth/core.clj
@@ -169,9 +169,10 @@
                   :body (json/write-str body)}
         response  @(post (eth-rpc-url) options)
         result   (safe-read-str (:body response))]
-    (log/infof "%s: eth-rpc %s" (or internal-tx-id "(no-tx-id)") method)
-    (log/debugf "eth-rpc req(%s) body: %s\neth-rpc req(%s) result: %s"
-                request-id body request-id result)
+    (when internal-tx-id
+      (log/infof "%s: eth-rpc %s" internal-tx-id method))
+    (log/debugf "%s: eth-rpc req(%s) body: %s" internal-tx-id request-id body)
+    (log/debugf "%s: eth-rpc req(%s) result: %s" internal-tx-id request-id result)
     (cond
       ;; Ignore any responses that have mismatching request ID
       (not= (:id result) request-id)

--- a/src/clj/commiteth/eth/core.clj
+++ b/src/clj/commiteth/eth/core.clj
@@ -349,7 +349,6 @@
   eth-core
   :start
   (do
-    (swap! web3j-obj (constantly nil))
     (swap! creds-obj (constantly nil))
     (log/info "eth/core started"))
   :stop

--- a/src/clj/commiteth/eth/multisig_wallet.clj
+++ b/src/clj/commiteth/eth/multisig_wallet.clj
@@ -110,7 +110,8 @@
   (log/debug "multisig/watch-token" bounty-addr token)
   (let [token-address (get-token-address token)]
     (assert token-address)
-    (eth/execute {:from      (eth/eth-account)
+    (eth/execute {:internal-tx-id (str "watch-token-" (System/currentTimeMillis) "-" bounty-addr)
+                  :from      (eth/eth-account)
                   :contract  bounty-addr
                   :method-id (:watch method-ids)
                   :gas-limit nil

--- a/src/clj/commiteth/eth/multisig_wallet.clj
+++ b/src/clj/commiteth/eth/multisig_wallet.clj
@@ -1,6 +1,5 @@
 (ns commiteth.eth.multisig-wallet
-  (:require [commiteth.eth.core :as eth
-             :refer [create-web3j creds]]
+  (:require [commiteth.eth.core :as eth]
             [commiteth.config :refer [env]]
             [clojure.tools.logging :as log]
             [taoensso.tufte :as tufte :refer (defnp p profiled profile)]
@@ -36,24 +35,19 @@
   []
   (env :tokenreg-base-format :status))
 
-(defn create-new
-  [owner1 owner2 required]
-  (eth/execute (eth/eth-account)
-               (factory-contract-addr)
-               (:create method-ids)
-               (eth/integer->hex 865000) ;; gas-limit
-               0x40
-               0x2
-               required
-               owner1
-               owner2))
-
-
 (defn deploy-multisig
   "Deploy a new multisig contract to the blockchain with commiteth bot
-  and given owner as owners."
-  [owner]
-  (create-new (eth/eth-account) owner 2))
+  and given owner as owners.
+  `internal-tx-id` is used to identify what issue this multisig is deployed
+  for and manage nonces at a later point in time."
+  [{:keys [owner internal-tx-id]}]
+  {:pre [(string? owner) (string? internal-tx-id)]}
+  (eth/execute {:internal-tx-id internal-tx-id
+                :from      (eth/eth-account)
+                :contract  (factory-contract-addr)
+                :method-id (:create method-ids)
+                :gas-limit (eth/integer->hex 865000)
+                :params    [0x40 0x2 2 (eth/eth-account) owner]}))
 
 (defn find-event-in-tx-receipt [tx-receipt topic-id]
   (let [logs (:logs tx-receipt)
@@ -92,20 +86,18 @@
 
 
 (defn send-all
-  [contract to]
-  (log/debug "multisig/send-all " contract to)
+  [{:keys [contract payout-address internal-tx-id]}]
+  {:pre [(string? contract) (string? payout-address) (string? internal-tx-id)]}
+  (log/debug "multisig/send-all " contract payout-address internal-tx-id)
   (let [params (eth/format-call-params
                 (:withdraw-everything method-ids)
-                to)]
-    (eth/execute (eth/eth-account)
-                 contract
-                 (:submit-transaction method-ids)
-                 nil
-                 contract
-                 0
-                 "0x60" ;; TODO: document these
-                 "0x24" ;;  or refactor out
-                 params)))
+                payout-address)]
+    (eth/execute {:internal-tx-id internal-tx-id
+                  :from      (eth/eth-account)
+                  :contract  contract
+                  :method-id (:submit-transaction method-ids)
+                  :gas-limit nil
+                  :params    [contract 0 "0x60" "0x24" params]})))
 
 
 (defn get-token-address [token]
@@ -118,17 +110,16 @@
   (log/debug "multisig/watch-token" bounty-addr token)
   (let [token-address (get-token-address token)]
     (assert token-address)
-    (eth/execute (eth/eth-account)
-                 bounty-addr
-                 (:watch method-ids)
-                 nil
-                 token-address)))
-
+    (eth/execute {:from      (eth/eth-account)
+                  :contract  bounty-addr
+                  :method-id (:watch method-ids)
+                  :gas-limit nil
+                  :params    [token-address]})))
 
 (defn load-bounty-contract [addr]
   (MultiSigTokenWallet/load addr
-    (create-web3j)
-    (creds)
+    @eth/web3j-obj
+    (eth/creds)
     (eth/gas-price)
     (BigInteger/valueOf 500000)))
 

--- a/src/clj/commiteth/eth/token_registry.clj
+++ b/src/clj/commiteth/eth/token_registry.clj
@@ -1,6 +1,5 @@
 (ns commiteth.eth.token-registry
-  (:require [commiteth.eth.core :as eth
-             :refer [create-web3j creds]]
+  (:require [commiteth.eth.core :as eth]
             [commiteth.config :refer [env]]
             [clojure.tools.logging :as log])
   (:import [org.web3j
@@ -23,8 +22,8 @@
 
 (defn- load-tokenreg-contract [addr]
   (TokenReg/load addr
-                 (create-web3j)
-                 (creds)
+                 @eth/web3j-obj
+                 (eth/creds)
                  (eth/gas-price)
                  (BigInteger/valueOf 21000)))
 
@@ -59,9 +58,8 @@
 (defn deploy-parity-tokenreg
   "Deploy an instance of parity token-registry to current network"
   []
-  (let [web3j (create-web3j)]
-    (TokenReg/deploy web3j
-                     (creds)
-                     (eth/gas-price)
-                     (BigInteger/valueOf 4000000) ;; gas limit
-                     BigInteger/ZERO)))
+  (TokenReg/deploy @eth/web3j-obj
+                   (eth/creds)
+                   (eth/gas-price)
+                   (BigInteger/valueOf 4000000) ;; gas limit
+                   BigInteger/ZERO))

--- a/src/clj/commiteth/scheduler.clj
+++ b/src/clj/commiteth/scheduler.clj
@@ -126,7 +126,9 @@
                                                    tokens
                                                    winner-login
                                                    true))
-             (let [execute-hash (multisig/send-all contract-address payout-address)]
+             (let [execute-hash (multisig/send-all {:contract contract-address
+                                                    :payout-address payout-address
+                                                    :internal-tx-id (str "payout-github-issue-" issue-id)})]
                (log/infof "issue %s: Payout self-signed, called sign-all(%s) tx: %s" issue-id contract-address payout-address execute-hash)
                (db-bounties/update-execute-hash issue-id execute-hash)
                (db-bounties/update-winner-login issue-id winner-login)


### PR DESCRIPTION
##### QA Notes

This addresses #399 by tracking each Ethereum transaction we're doing and incrementing nonces manually if necessary. Because this was a bit more involved code-wise the following things need to be tested thoroughly:

- deployment of contracts
- bounty payout

As we were not able to reproduce #399 on Staging/Ropsten we should test if this PR still works as before on staging and once it's merged into production we can verify that it actually fixes #399. 