### PR TITLE
fix padding for dropdown claims

### DIFF
--- a/src/cljs/commiteth/bounties.cljs
+++ b/src/cljs/commiteth/bounties.cljs
@@ -269,7 +269,7 @@
         [:div.view-loading-container
          [:div.ui.active.inverted.dimmer
           [:div.ui.text.loader.view-loading-label "Loading"]]]
-        [:div.ui.container.open-bounties-container.
+        [:div.ui.container.open-bounties-container
          {:ref #(reset! container-element %1)}
          [:div.open-bounties-header.ph4.pt4 "Bounties"]
          [:div.open-bounties-filter-and-sort.ph4

--- a/src/cljs/commiteth/bounties.cljs
+++ b/src/cljs/commiteth/bounties.cljs
@@ -13,7 +13,7 @@
             [commiteth.util :as util]))
 
 (defn display-bounty-claims [claims]
-  [:div.bounty-claims-container.pv3
+  [:div.bounty-claims-container.ph4.pv3
    (for [claim claims]
      (let [{:keys [avatar-url
                    pr-title
@@ -65,7 +65,7 @@
             close-claims-click     #(rf/dispatch [::handlers/close-bounty-claim issue-id])
             matches-current-issue? (some #{issue-id} @open-bounty-claims)]
             [:div
-             [:div.open-bounty-item
+             [:div.open-bounty-item.ph4
               [:div.open-bounty-item-content
                [:div.header issue-link]
                [:div.bounty-item-row
@@ -254,7 +254,7 @@
     [:div
      (let [left  (inc (* (dec page-number) items-per-page))
            right (dec (+ left item-count))]
-       [:div.item-counts-label-and-sorting-container
+       [:div.item-counts-label-and-sorting-container.ph4
         [:div.item-counts-label
          [:span (str "Showing " left "-" right " of " total-count)]]
         [bounties-sort-view]])
@@ -269,9 +269,9 @@
         [:div.view-loading-container
          [:div.ui.active.inverted.dimmer
           [:div.ui.text.loader.view-loading-label "Loading"]]]
-        [:div.ui.container.open-bounties-container
+        [:div.ui.container.open-bounties-container.
          {:ref #(reset! container-element %1)}
-         [:div.open-bounties-header "Bounties"]
-         [:div.open-bounties-filter-and-sort
+         [:div.open-bounties-header.ph4.pt4 "Bounties"]
+         [:div.open-bounties-filter-and-sort.ph4
           [bounty-filters-view]]
          [bounties-list @bounty-page-data container-element]]))))

--- a/src/cljs/commiteth/common.cljs
+++ b/src/cljs/commiteth/common.cljs
@@ -135,7 +135,7 @@
           :else 
           [:div
            [draw-items] 
-           [:div.page-nav-container
+           [:div.page-nav-container.ph4.pb4
             [:div.page-direction-container
              [draw-rect :backward]
              [draw-rect :forward]]

--- a/src/less/style.less
+++ b/src/less/style.less
@@ -415,7 +415,6 @@ label[for="input-hidden"] {
     background-color: #fff;
     border-radius: 10px;
     transform: translateY(-45px);
-    padding: 24px;
     .open-bounties-header {
         font-family: "PostGrotesk-Medium";
         font-size: 21px;


### PR DESCRIPTION
## About
The grey box containing claims info will run to the entire width of the column. 

### Before
<img width="1209" alt="before" src="https://user-images.githubusercontent.com/909156/38817431-593fde88-4166-11e8-9b15-174495de6fdf.png">

### After
<img width="1045" alt="after" src="https://user-images.githubusercontent.com/909156/38817461-7006a5ac-4166-11e8-98fa-7efaf7f383ae.png">

## Additional Considerations
- [x] make sure padding is correct in case of "no matching data found"
- [x] Do we still need the activities page in light of #359 being merged? (question has been posed. if we decide to remove that page then it should happen in a separate PR from this one)
