### PR TITLE
WIP migration: add unique constraint on transaction_hash column

### DIFF
--- a/resources/migrations/20180419153800-enforce-unique-tx-hash.down.sql
+++ b/resources/migrations/20180419153800-enforce-unique-tx-hash.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE issues DROP CONSTRAINT transaction_hash_uniq;

--- a/resources/migrations/20180419153800-enforce-unique-tx-hash.up.sql
+++ b/resources/migrations/20180419153800-enforce-unique-tx-hash.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE issues ADD CONSTRAINT transaction_hash_uniq UNIQUE (transaction_hash);


### PR DESCRIPTION
We repeatedly ran into the issue that deployment of bounty contracts resulted in the same TX (and eventually contract) being associated with a bounty. This is broken and so this constraint on the Postgres table should help with ensuring that this does not happen anymore.