### PR TITLE
fix #432 load more activities

### DIFF
--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -609,7 +609,7 @@ SELECT
   updated
 FROM activity_feed_view
 ORDER BY updated DESC
-LIMIT 100;
+LIMIT 1000;
 
 -- :name get-new-users-for-welcome-email :? :*
 -- :doc users who have not been sent a welcome email


### PR DESCRIPTION
Fixes #432 

Loading to few activities can cause claims not being displayed as claims and bounties are loaded via separate XHR requests. This change implements a quick fix around that making old activities show up.

Long term we should move claims into the response of `/api/open-bounties` so that they always are available for bounties shown in the UI.

This is also somewhat related to better API pagination as described in https://github.com/status-im/open-bounty/issues/250