### PR TITLE
make working with eth gas station more manageable 

### DIFF
--- a/src/clj/commiteth/eth/core.clj
+++ b/src/clj/commiteth/eth/core.clj
@@ -48,7 +48,10 @@
     (try
       (eth-gasstation-gas-price)
       (catch Throwable t
-        (log/error "Failed to get gas price with ethgasstation API" t)
+        (let [cause (-> t
+                        Throwable->map
+                        :cause)]
+         (log/error "Failed to get gas price with ethgasstation API" cause))
         (gas-price-from-config)))
     (gas-price-from-config)))
 


### PR DESCRIPTION
Now that we are using eth gas station, we are subject to some timeouts from their api. The error message from cloudfront was quite long so this PR aims to extract just the root cause (in this case a timeout or other error code) so that we humans can understand this message without losing sight of everything else going on. 

Somewhat related to this is that I bumped the default gas price on prod to 10 instead of 5gwei, which is more in keeping with the averages we've been seeing, so that is the new value that will be used if eth gas station is taking too long to respond. 

I had considered a caching/memoization strategy for eth gas station, but given somewhat limited understanding of the volatility of that market, I thought that might do more harm than good in the end versus our current system which is easy to reason about.  