### PR TITLE
store currently confirming payouts in local storage

### DIFF
--- a/src/cljs/commiteth/handlers.cljs
+++ b/src/cljs/commiteth/handlers.cljs
@@ -425,6 +425,14 @@
 (defn strip-0x [x]
   (str/replace x #"^0x" ""))
 
+(reg-event-fx
+ :set-confirming-payout
+ [interceptors (inject-cofx :store)]
+ (fn [{:keys [db store]} [_  issue-id]]
+   {:db (assoc-in db [:owner-bounties issue-id :confirming?] true)
+    :store (assoc-in store [:owner-bounties issue-id :confirming?] true)}))
+
+
 (defn set-pending-revocation [location issue-id confirming-account]
   (assoc-in location [::db/pending-revocations issue-id]
             {:confirming-account confirming-account}))
@@ -503,9 +511,9 @@
                   :data data}]
      (println "data:" data)
      (try
+       (dispatch [:set-confirming-payout issue-id])
        (web3-eth/send-transaction! w3 payload
                                    (send-transaction-callback issue-id pending-revocations))
-       {:db (assoc-in db [:owner-bounties issue-id :confirming?] true)}
        (catch js/Error e
          {:db (assoc-in db [:owner-bounties issue-id :confirm-failed?] true)
           :dispatch-n [[:payout-confirm-failed issue-id e]
@@ -515,20 +523,23 @@
 
 (reg-event-fx
  :payout-confirmed
- interceptors
+ [interceptors [(inject-cofx :store)]]
  (fn [{:keys [db]} [_ issue-id]]
    {:dispatch [:load-owner-bounties]
     :db (-> db
             (dissoc-in [:owner-bounties issue-id :confirming?])
-            (assoc-in [:owner-bounties  issue-id :confirmed?] true))}))
+            (assoc-in [:owner-bounties  issue-id :confirmed?] true))
+    :store (dissoc-in store [:owner-bounties issue-id :confirming?])}))
 
-(reg-event-db
+(reg-event-fx
  :payout-confirm-failed
- (fn [db [_ issue-id e]]
+ [(inject-cofx :store)]
+ (fn [{:keys  [db store]} [_ issue-id e]]
    (println "payout-confirm-failed" issue-id e)
-   (-> db
-       (dissoc-in [:owner-bounties issue-id :confirming?])
-       (assoc-in [:owner-bounties issue-id :confirm-failed?] true))))
+   {:db (-> db
+            (dissoc-in [:owner-bounties issue-id :confirming?])
+            (assoc-in [:owner-bounties issue-id :confirm-failed?] true))
+    :store (dissoc-in store [:owner-bounties issue-id :confirming?])}))
 
 
 (reg-event-fx

--- a/src/cljs/commiteth/handlers.cljs
+++ b/src/cljs/commiteth/handlers.cljs
@@ -527,8 +527,8 @@
  (fn [{:keys [db]} [_ issue-id]]
    {:dispatch [:load-owner-bounties]
     :db (-> db
-            (dissoc-in [:owner-bounties issue-id :confirming?])
-            (assoc-in [:owner-bounties  issue-id :confirmed?] true))
+            (assoc-in [:owner-bounties  issue-id :confirmed?] true)
+            (dissoc-in [:owner-bounties issue-id :confirming?]))
     :store (dissoc-in store [:owner-bounties issue-id :confirming?])}))
 
 (reg-event-fx

--- a/src/cljs/commiteth/manage_payouts.cljs
+++ b/src/cljs/commiteth/manage_payouts.cljs
@@ -68,24 +68,26 @@
 
 
 (defn confirm-row [bounty claim]
-  (let [payout-address-available? (:payout_address bounty)]
-    [:div
-     (when-not payout-address-available?
-       [:div.bg-sob-blue-o-20.pv2.ph3.br3.mb3.f6
-        [:p [:span.pg-med (or (:user_name claim) (:user_login claim))
-             "’s payment address is pending."] " You will be able to confirm the payment once the address is provided."]])
-     [:div.cf
-      [:div.dt.fr
+  (let [payout-address-available? (:payout_address bounty)
+        confirmed?                (:confirmed? bounty)]
+    (when-not confirmed?
+      [:div
        (when-not payout-address-available?
-         {:style {:-webkit-filter "grayscale(1)"
-                  :pointer-events "none"}})
-       [:div.dtc.v-mid.pr3.f6
-        [:div
-         [ui-balances/token-balances (bnt/crypto-balances bounty) :badge]
-         [:div.dib.mr2.pv1
-          [ui-balances/usd-value-label (:value-usd bounty)]]]]
-       [:div.dtc.v-mid
-        [confirm-button bounty claim]]]]]))
+         [:div.bg-sob-blue-o-20.pv2.ph3.br3.mb3.f6
+          [:p [:span.pg-med (or (:user_name claim) (:user_login claim))
+               "’s payment address is pending."] " You will be able to confirm the payment once the address is provided."]])
+       [:div.cf
+        [:div.dt.fr
+         (when-not payout-address-available?
+           {:style {:-webkit-filter "grayscale(1)"
+                    :pointer-events "none"}})
+         [:div.dtc.v-mid.pr3.f6
+          [:div
+           [ui-balances/token-balances (bnt/crypto-balances bounty) :badge]
+           [:div.dib.mr2.pv1
+            [ui-balances/usd-value-label (:value-usd bounty)]]]]
+         [:div.dtc.v-mid
+          [confirm-button bounty claim]]]]])))
 
 (defn view-pr-button [claim]
   [primary-button-link

--- a/src/cljs/commiteth/manage_payouts.cljs
+++ b/src/cljs/commiteth/manage_payouts.cljs
@@ -52,21 +52,18 @@
        (common/human-time updated)]]]]])
 
 (defn confirm-button [bounty claim]
-  (let [paid?   (bnt/paid? claim)
-        merged? (bnt/merged? claim)]
-    (when (and merged? (not paid?))
+  (let [paid?        (bnt/paid? claim)
+        merged?      (bnt/merged? claim)
+        confirming?  (bnt/confirming? bounty)
+        bot-unmined? (bnt/bot-confirm-unmined? bounty)]
+    (when (and merged?
+               (:payout_address bounty)
+               (not paid?)
+               (not confirming?)
+               (not bot-unmined?))
       [primary-button-button
-       (merge {:on-click #(rf/dispatch [:confirm-payout claim])}
-              (if (and merged? (not paid?) (:payout_address bounty))
-                {}
-                {:disabled true})
-              (when (and (or (bnt/confirming? bounty)
-                             (bnt/bot-confirm-unmined? bounty))
-                         merged?)
-                {:class "busy loading" :disabled true}))
-       (if paid?
-         "Signed off"
-         "Confirm Payment")])))
+       {:on-click #(rf/dispatch [:confirm-payout claim])}
+       "Confirm Payment"])))
 
 
 


### PR DESCRIPTION
The main change here is that the `confirming?` flag is being persisted in local storage, as before there was no record of whether a confirm payout had been initiated if the page was refreshed. 

Additionally the confirm button itself will be hidden during confirmation. Previously it was set to a disabled state that was not discernibly different different from the active state, which may have been the source of confusion. 

So to be clear this won't materially guarantee that the payout hash is set, but it should make it easier to spot if the problem happens again, and users won't even be given the option to confirm the payout multiple times. 