### PR TITLE
[#384] Move PNGs with QR codes out of DB

### DIFF
--- a/env/dev/resources/config.edn
+++ b/env/dev/resources/config.edn
@@ -51,4 +51,7 @@
  :user-whitelist #{}
 
  ;; used for blacklisting tokens from token registry data
- :token-blacklist #{}}
+ :token-blacklist #{}
+
+ ;; directory to store qr images, relative to resources/public or absolute path
+ :qr-dir ""}

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -621,6 +621,11 @@ FROM issue_comment
 WHERE issue_id = :issue_id
 AND comment_hash = :hash;
 
+-- :name get-issue-comment-hash :? :1
+-- :doc retrieve image hash for given issue's github comment
+SELECT comment_hash
+FROM issue_comment
+WHERE issue_id = :issue_id;
 
 -- :name top-hunters :? :*
 -- :doc top 5 list of users that have reveived bounty payouts with sum of

--- a/src/clj/commiteth/db/comment_images.clj
+++ b/src/clj/commiteth/db/comment_images.clj
@@ -11,6 +11,12 @@
                                    :hash hash
                                    :png_data png-data})))
 
+(defn get-hash
+  [issue-id]
+  (:comment-hash
+   (jdbc/with-db-connection [con-db *db*]
+     (db/get-issue-comment-hash con-db {:issue_id issue-id}))))
+
 (defn get-image-data
   [issue-id hash]
   (jdbc/with-db-connection [con-db *db*]

--- a/src/clj/commiteth/handler.clj
+++ b/src/clj/commiteth/handler.clj
@@ -11,7 +11,8 @@
             [ring.middleware.keyword-params :refer [wrap-keyword-params]]
             [commiteth.env :refer [defaults]]
             [mount.core :as mount]
-            [commiteth.middleware :as middleware]))
+            [commiteth.middleware :as middleware]
+            [commiteth.config :refer [env]]))
 
 (mount/defstate init-app
   :start ((or (:init defaults) identity))
@@ -19,15 +20,16 @@
 
 (def app-routes
   (routes
-    #'webhook-routes
-    (middleware/wrap-base
-     (routes
-      (-> #'home-routes
-          (wrap-routes middleware/wrap-csrf)
-          (wrap-routes middleware/wrap-formats))
-      #'redirect-routes
-      #'service-routes
-      #'qr-routes
+   #'webhook-routes
+   (middleware/wrap-base
+    (routes
+     (-> #'home-routes
+         (wrap-routes middleware/wrap-csrf)
+         (wrap-routes middleware/wrap-formats))
+     #'redirect-routes
+     #'service-routes
+     #'qr-routes
+     (route/files "/qr-image" {:root (:qr-dir env)})
      (route/not-found
       (:body
        (error-page {:status 404

--- a/src/clj/commiteth/routes/qrcodes.clj
+++ b/src/clj/commiteth/routes/qrcodes.clj
@@ -7,7 +7,8 @@
             [clojure.tools.logging :as log])
   (:import [java.io ByteArrayInputStream]))
 
-
+;; TODO(endenwer) qr is handler as static image now. This route is used for old comments.
+;; Remove it when it is not necessary anymore.
 (defapi qr-routes
   (context "/qr" []
            (GET "/:owner/:repo/bounty/:issue{[0-9]{1,9}}/:hash/qr.png" [owner repo issue hash]
@@ -19,7 +20,7 @@
                   (do
                     (log/debug "address:" contract-address)
                     (log/debug owner repo issue balance-eth)
-                    (log/debug hash (github/github-comment-hash owner repo issue balance-eth))
+                    (log/debug hash)
                     (if contract-address
                       (if-let [{:keys [png-data]}
                                (comment-images/get-image-data


### PR DESCRIPTION
fixes #384

### Summary:
Store qr images on filesystem. Storage folder can be specified in config env `:qr-dir`. All new comment images will be stored on filesystem. Old comment images will remain the same until it will be updated by balance change. No need for any migrations.

### Testing notes:
Testing server http://209.97.165.226/ It will be online for a week.
Test bounty issue with new image https://github.com/endenwer/status-react/issues/13
Test bounty issue with old image https://github.com/endenwer/status-react/issues/6

### Steps to test:
- Create bounty as described in testing instruction https://github.com/status-im/open-bounty/blob/develop/doc/testing.md#creating-bounty-issues 

status: ready
