### PR TITLE
update log level for eth gas station api from error to debug

### DIFF
--- a/src/clj/commiteth/eth/core.clj
+++ b/src/clj/commiteth/eth/core.clj
@@ -51,7 +51,7 @@
         (let [cause (-> t
                         Throwable->map
                         :cause)]
-         (log/error "Failed to get gas price with ethgasstation API" cause))
+         (log/debug "Failed to get gas price with ethgasstation API" cause))
         (gas-price-from-config)))
     (gas-price-from-config)))
 


### PR DESCRIPTION
These logs in particular account for the majority of the error emails we get. Since eth gas station times out as much as it works normally, and we have a sensible default for when this happens, I think it makes sense to lower the log level. 

Hopefully this will help us spot issues other issues that actually matter while `sob` is in maintenance mode :+1: 