### PR TITLE
always show manage bounties tab

### DIFF
--- a/src/cljs/commiteth/core.cljs
+++ b/src/cljs/commiteth/core.cljs
@@ -81,8 +81,7 @@
       (let [route-id (:route-id @route)
             tabs [[:bounties (str (when-not @user "Open ") "Bounties")]
                   [:activity "Activity"]
-                  (when (seq @owner-bounties)
-                    [:dashboard "Manage bounties"])
+                  [:dashboard "Manage bounties"]
                   (when (:status-team-member? @user)
                     [:usage-metrics "Usage metrics"])]]
         (into [:div.ui.attached.tabular.menu.tiny]


### PR DESCRIPTION
Since the scope of the manage bounties tab has grown with revocations, I think it makes sense to get rid of the check hiding the tab unless there are owner bounties present (which require a winner login set on the issue). 

This is also specifically meant to resolve some issues currently being seen in production so it would be nice to get out the door. 